### PR TITLE
Issues/274

### DIFF
--- a/scripts/convert_merged_tract_to_dpdd.py
+++ b/scripts/convert_merged_tract_to_dpdd.py
@@ -49,6 +49,8 @@ def convert_all_to_dpdd(reader='dc2_coadd_run1.1p', **kwargs):
     """
     trim_config = {'filename_pattern': 'trim_merged_tract_.*\.hdf5$'}
     cat = GCRCatalogs.load_catalog(reader, trim_config)
+    # We don't want to use the cache because we know we are just going through the data once.
+    cat.use_cache = False
 
     convert_cat_to_dpdd(cat, **kwargs)
 
@@ -75,6 +77,8 @@ def convert_tract_to_dpdd(tract, reader='dc2_coadd_run1.1p', **kwargs):
     trim_thistract_config = {
         'filename_pattern': 'trim_merged_tract_{:04d}\.hdf5$'.format(tract)}
     cat = GCRCatalogs.load_catalog(reader, trim_thistract_config)
+    # We don't want to use the cache because we know we are just going through the data once.
+    cat.use_cache = False
 
     convert_cat_to_dpdd(cat, **kwargs)
 

--- a/scripts/convert_merged_tract_to_dpdd.py
+++ b/scripts/convert_merged_tract_to_dpdd.py
@@ -114,6 +114,7 @@ def write_dataframe_to_files(
         df,
         filename_prefix='dpdd_object',
         hdf_key_prefix='object',
+        parquet_scheme='hive',
         parquet_engine='fastparquet',
         parquet_compression='gzip',
         append=True,
@@ -178,6 +179,7 @@ def write_dataframe_to_files(
     parquet_append = append and os.path.exists(parquet_file)
     df.to_parquet(parquet_file,
                   append=parquet_append,
+                  file_scheme=parquet_scheme,
                   engine=parquet_engine,
                   compression=parquet_compression)
 # Consider uses a file format other than 'simple' to enable partition.


### PR DESCRIPTION
Creates an HDF5, Parquet, and FITS versions with columns named and computed as in the LSST DPDD.

* The HDF5 files are split by tract.
  - The HDF5 files have group keys of 'object_<tract>_<patch>', e.g., 'object_4850_31' for tract 4850 and patch 31 (also referred to as '3,1')
* The Parquet files are split by tract.
   - The are stored in a scheme compatible with Apache Hive.
* The FITS files are split by tract and patch because I don't know how to sequentially append Pandas Dataframes to a FITS file in a straightforward way.
