### PR TITLE
Issues/289

### DIFF
--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -205,6 +205,8 @@ def load_patch(butler_or_repo, tract, patch,
                 print(" ", e)
             continue
 
+        if verbose:
+            print("AFW photometry catalog schema version: {}".format(cat.schema.VERSION))
         flux_names = flux_field_names_per_schema_version[cat.schema.VERSION]
 
         # Convert the AFW table to an AstroPy table

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -140,7 +140,8 @@ def load_patch(butler_or_repo, tract, patch,
                fields_to_join=('id',),
                filters={'u': 'u', 'g': 'g', 'r': 'r', 'i': 'i', 'z': 'z', 'y': 'y'},
                trim_colnames_for_fits=False,
-               verbose=False
+               verbose=False,
+               debug=False
                ):
     """Load patch catalogs.  Return merged catalog across filters.
 
@@ -205,7 +206,7 @@ def load_patch(butler_or_repo, tract, patch,
                 print(" ", e)
             continue
 
-        if verbose:
+        if debug:
             print("AFW photometry catalog schema version: {}".format(cat.schema.VERSION))
         flux_names = flux_field_names_per_schema_version[cat.schema.VERSION]
 

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -184,33 +184,50 @@ def load_patch(butler_or_repo, tract, patch,
             print("  No good isPrimary entries for tract %d, patch %s" % (tract, patch))
         return ref_table
 
+    flux_field_names_per_schema_version = {
+        1: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxSigma',
+              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxSigma'},
+        2: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxErr',
+              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxErr'},
+        3: {'psf_flux': 'base_PsfFlux_instFlux', 'psf_flux_err': 'base_PsfFlux_instFluxErr',
+              'modelfit_flux': 'modelfit_CModel_instFlux', 'modelfit_flux_err': 'modelfit_CModel_instFluxErr'},
+    }
+
     merge_filter_cats = {}
     for filt in filters:
         this_data = tract_patch_data_id.copy()
         this_data['filter'] = filters[filt]
         try:
             cat = butler.get(datasetType='deepCoadd_forced_src',
-                             dataId=this_data).asAstropy()
+                             dataId=this_data)
         except NoResults as e:
             if verbose:
                 print(" ", e)
             continue
 
+        flux_names = flux_field_names_per_schema_version[cat.schema.VERSION]
+
+        # Convert the AFW table to an AstroPy table
+        # because it's much easier to add column to an AstroPy table
+        # than it is to set up a new schema for an AFW table.
+        cat = cat.asAstropy()
+
         calib = butler.get('deepCoadd_calexp_calib', this_data)
         calib.setThrowOnNegativeFlux(False)
 
-        import pdb; pdb.set_trace();
-        mag, mag_err = calib.getMagnitude(cat['base_PsfFlux_instFlux'], cat['base_PsfFlux_instFluxErr'])
+        mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']], cat[flux_names['psf_flux_err']])
 
         cat['mag'] = mag
         cat['mag_err'] = mag_err
-        cat['SNR'] = np.abs(cat['base_PsfFlux_instFlux'])/cat['base_PsfFlux_instFluxErr']
+        cat['SNR'] = np.abs(cat[flux_names['psf_flux']])/cat[flux_names['psf_flux']]
 
-        modelfit_mag, modelfit_mag_err = calib.getMagnitude(cat['modelfit_CModel_instFlux'], cat['modelfit_CModel_instFluxErr'])
+        modelfit_mag, modelfit_mag_err = calib.getMagnitude(cat[flux_names['modelfit_flux']],
+                                                            cat[flux_names['modelfit_flux_err']])
 
         cat['modelfit_mag'] = modelfit_mag
         cat['modelfit_mag_err'] = modelfit_mag_err
-        cat['modelfit_SNR'] = np.abs(cat['modelfit_CModel_instFlux'])/cat['modelfit_CModel_instFluxErr']
+        cat['modelfit_SNR'] = np.abs(cat[flux_names['modelfit_flux']] /
+                                     cat[flux_names['modelfit_flux_err']])
 
         cat = cat[isPrimary]
 

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -221,7 +221,8 @@ def load_patch(butler_or_repo, tract, patch,
 
         cat['mag'] = mag
         cat['mag_err'] = mag_err
-        cat['SNR'] = np.abs(cat[flux_names['psf_flux']])/cat[flux_names['psf_flux']]
+        cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
+                            cat[flux_names['psf_flux_err']])
 
         modelfit_mag, modelfit_mag_err = calib.getMagnitude(cat[flux_names['modelfit_flux']],
                                                             cat[flux_names['modelfit_flux_err']])

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -199,17 +199,17 @@ def load_patch(butler_or_repo, tract, patch,
         CoaddCalib = butler.get('deepCoadd_calexp_calib', this_data)
         CoaddCalib.setThrowOnNegativeFlux(False)
 
-        mag, mag_err = CoaddCalib.getMagnitude(cat['base_PsfFlux_flux'], cat['base_PsfFlux_fluxSigma'])
+        mag, mag_err = CoaddCalib.getMagnitude(cat['base_PsfFlux_instFlux'], cat['base_PsfFlux_instFluxErr'])
 
         cat['mag'] = mag
         cat['mag_err'] = mag_err
-        cat['SNR'] = np.abs(cat['base_PsfFlux_flux'])/cat['base_PsfFlux_fluxSigma']
+        cat['SNR'] = np.abs(cat['base_PsfFlux_instFlux'])/cat['base_PsfFlux_instFluxErr']
 
-        modelfit_mag, modelfit_mag_err = CoaddCalib.getMagnitude(cat['modelfit_CModel_flux'], cat['modelfit_CModel_fluxSigma'])
+        modelfit_mag, modelfit_mag_err = CoaddCalib.getMagnitude(cat['modelfit_CModel_instFlux'], cat['modelfit_CModel_instFluxErr'])
 
         cat['modelfit_mag'] = modelfit_mag
         cat['modelfit_mag_err'] = modelfit_mag_err
-        cat['modelfit_SNR'] = np.abs(cat['modelfit_CModel_flux'])/cat['modelfit_CModel_fluxSigma']
+        cat['modelfit_SNR'] = np.abs(cat['modelfit_CModel_instFlux'])/cat['modelfit_CModel_instFluxErr']
 
 
         cat = cat[isPrimary]

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -196,21 +196,21 @@ def load_patch(butler_or_repo, tract, patch,
                 print(" ", e)
             continue
 
-        CoaddCalib = butler.get('deepCoadd_calexp_calib', this_data)
-        CoaddCalib.setThrowOnNegativeFlux(False)
+        calib = butler.get('deepCoadd_calexp_calib', this_data)
+        calib.setThrowOnNegativeFlux(False)
 
-        mag, mag_err = CoaddCalib.getMagnitude(cat['base_PsfFlux_instFlux'], cat['base_PsfFlux_instFluxErr'])
+        import pdb; pdb.set_trace();
+        mag, mag_err = calib.getMagnitude(cat['base_PsfFlux_instFlux'], cat['base_PsfFlux_instFluxErr'])
 
         cat['mag'] = mag
         cat['mag_err'] = mag_err
         cat['SNR'] = np.abs(cat['base_PsfFlux_instFlux'])/cat['base_PsfFlux_instFluxErr']
 
-        modelfit_mag, modelfit_mag_err = CoaddCalib.getMagnitude(cat['modelfit_CModel_instFlux'], cat['modelfit_CModel_instFluxErr'])
+        modelfit_mag, modelfit_mag_err = calib.getMagnitude(cat['modelfit_CModel_instFlux'], cat['modelfit_CModel_instFluxErr'])
 
         cat['modelfit_mag'] = modelfit_mag
         cat['modelfit_mag_err'] = modelfit_mag_err
         cat['modelfit_SNR'] = np.abs(cat['modelfit_CModel_instFlux'])/cat['modelfit_CModel_instFluxErr']
-
 
         cat = cat[isPrimary]
 


### PR DESCRIPTION
Use renamed '_flux'->'_instFlux' columns for 'PsfFlux', 'modelfit_Cmodel' and the accompanying errors.