### PR TITLE
make trim_tract_cat.py more robust and faster

### DIFF
--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Create a restricted sample of an HDF5 merged coadd catalog
+Create a restricted sample of an HDF5 merged object catalog
 that contains only the columns necessary to support the DPDD
 columns exposed in the GCRCatalog DC2 reader
 """
@@ -14,7 +14,7 @@ import warnings
 import pandas as pd
 
 from GCRCatalogs import BaseGenericCatalog
-from GCRCatalogs.dc2_object import DC2ObjectCatalog
+from GCRCatalogs.dc2_object import DC2ObjectCatalog, GROUP_PATTERN
 
 
 class DummyDC2ObjectCatalog(BaseGenericCatalog):
@@ -33,20 +33,8 @@ class DummyDC2ObjectCatalog(BaseGenericCatalog):
         return set(self._translate_quantities(self.list_all_quantities()))
 
 
-def load_trim_save_patch(infile, outfile, patch, key_prefix='coadd',
-                         verbose=False, schema_version=None):
-    r = re.search('merged_tract_([0-9]+)\.', infile)
-    tract = int(r[1])
-
-    key = "%s_%s_%s" % (key_prefix, tract, patch)
-    try:
-        df = pd.read_hdf(infile, key=key)
-    except KeyError as e:
-        if verbose:
-            print(e)
-        return
-
-    columns_to_keep = DummyDC2ObjectCatalog(schema_version).required_native_quantities
+def load_trim_save_patch(outfile, infile_handle, key, columns_to_keep):
+    df = infile_handle.get_storer(key).read()
     if not columns_to_keep.issubset(df.columns):
         warnings.warn('Not all columns to keep are present in the data file.')
     columns_to_keep_present = list(columns_to_keep.intersection(df.columns))
@@ -54,10 +42,8 @@ def load_trim_save_patch(infile, outfile, patch, key_prefix='coadd',
     trim_df.to_hdf(outfile, key=key)
 
 
-def make_trim_file(infile, outfile=None, clobber=True):
-    # Note '%d%d' instead of '%d,%d'
-    nx, ny = 8, 8
-    patches = ['%d%d' % (i, j) for i in range(nx) for j in range(ny)]
+def make_trim_file(infile, outfile=None, clobber=True, schema_version=None,
+                   check_all_patches_exist=False):
 
     if outfile is None:
         dirname = os.path.dirname(infile)
@@ -65,12 +51,24 @@ def make_trim_file(infile, outfile=None, clobber=True):
         outfile = os.path.join(dirname, "trim_"+basename)
 
     # Remove existing outputfile
-    if clobber:
-        if os.path.exists(outfile):
-            os.remove(outfile)
+    if clobber and os.path.exists(outfile):
+        os.remove(outfile)
 
-    for patch in patches:
-        load_trim_save_patch(infile, outfile, patch)
+    columns_to_keep = DummyDC2ObjectCatalog(schema_version).required_native_quantities
+
+    patches = []
+    with pd.HDFStore(infile, 'r') as fh:
+        for key in fh:
+            if not re.match(GROUP_PATTERN, key.lstrip('/')):
+                continue
+            load_trim_save_patch(outfile, fh, key, columns_to_keep)
+            patches.append(key.rpartition('_')[-1])
+
+    if check_all_patches_exist:
+        nx, ny = 8, 8
+        patches_all = set(('%d%d' % (i, j) for i in range(nx) for j in range(ny)))
+        if not patches_all.issubset(patches):
+            warnings.warn('Some patches do not exist!')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Attempt to make `trim_tract_cat.py` more robust and faster by:
- use the keys in hdf5 files directly
- reduce the number of opening `infile`