### PR TITLE
Issues/286

### DIFF
--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+"""
+Write a GCR Catalog out to a Parquet file.
+
+pandas  # version >= 0.21
+generic-catalog-reader
+LSSTDESC/gcr-catalog
+
+and either
+pyarrow or fastparquet.
+"""
+
+
+import os
+import sys
+
+from astropy.table import Table
+import pandas as pd
+
+import GCRCatalogs
+
+
+def convert_all_to_dpdd(reader='dc2_coadd_run1.1p', **kwargs):
+    """Produce DPDD output files for all available tracts in GCR 'reader'.
+
+    The input filename is expected to match 'trim_merged_tract_.*\.hdf5$'.
+
+    Parameters
+    ----------
+    reader : str, optional
+        GCR reader to use. Must match an existing yaml file.
+        Default is dc2_coadd_run1.1p
+
+    Other Parameters
+    ----------------
+    **kwargs
+        *kwargs* are optional properties writing the dataframe to files.
+        See `write_dataframe_to_files` for more information.
+
+    """
+    cat = GCRCatalogs.load_catalog(reader)
+    # We don't want to use the cache we don't want to use the extra memory
+    # when we know we are just going through the data once.
+    cat.use_cache = False
+
+    convert_cat_to_dpdd(cat, **kwargs)
+
+
+def convert_cat_to_dpdd(cat, include_native=True, **kwargs):
+    """Save columns from input GCR catalog.
+
+    Parameters
+    ----------
+    cat : GCRCatalog instance
+        Catalog instance returned by `GCRCatalogs.load_catalog`.
+
+    Other Parameters
+    ----------------
+    **kwargs
+        *kwargs* are optional properties writing the dataframe to files.
+        See `write_dataframe_to_files` for more information.
+    """
+    columns = cat.list_all_quantities(include_native=include_native)
+
+    quantities = cat.get_quantities(columns, return_iterator=True)
+    for quantities_this_chunk in quantities:
+        quantities_this_chunk = pd.DataFrame.from_dict(quantities_this_chunk)
+        write_dataframe_to_files(quantities_this_chunk, **kwargs)
+
+
+def write_dataframe_to_files(
+        df,
+        filename_prefix='cat',
+        parquet_scheme='hive',
+        parquet_engine='fastparquet',
+        parquet_compression='gzip',
+        append=True,
+        verbose=True,
+        **kwargs):
+    """Write out dataframe to Parquet file.
+
+    Parameters
+    ----------
+    df : Pandas DataFrame
+        Pandas DataFrame with the input catalog data to write out.
+    filename_prefix : str, optional
+        Prefix to be added to the output filename. Default is 'cat'.
+    parquet_scheme : str, optional   ['simple' or 'hive']
+            'simple' stores everything in one file per tract
+            'hive' stores one directory with a _metadata file and then
+                the columns partitioned into row groups.
+            Default is simple
+    parquet_engine : str, optional
+        Engine to write parquet on disk. Available: fastparquet, pyarrow.
+        Default is fastparquet.
+    parquet_compression : str, optional
+        Compression algorithm to use when writing Parquet files.
+        Potential: gzip, snappy, lzo, uncompressed. Default is gzip.
+        Availability depends on the engine used.
+    verbose : boolean, optional
+        If True, print out debug messages. Default is True.
+    """
+    # Normalise output filename
+    outfile = '{}.{}'.format(filename_prefix, 'parquet')
+
+    if verbose:
+        print("Writing chunk {} to Parquet file.".format(df))
+    # Append iff the file already exists
+    parquet_append = append and os.path.exists(parquet_file)
+    df.to_parquet(parquet_file,
+                  append=parquet_append,
+                  file_scheme=parquet_scheme,
+                  engine=parquet_engine,
+                  compression=parquet_compression)
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser, RawTextHelpFormatter
+    usage = """
+Produce Parquet output files from GCR catalogs.
+
+Example:
+
+To produce files for all data call with:
+
+python %(prog)s
+
+To specify a different reader and produce files for all available tracts:
+
+python %(prog)s --reader dc2_object_run1.2p
+
+You can also specify the engine to use to write parquet files, and the
+compression algorithm to use:
+
+python %(prog)s
+    --parquet_scheme hive
+    --parquet_engine fastparquet
+    --parquet_compression gzip
+
+The selected engine needs to be installed on your machine to use.  E.g.,
+
+pip install fastparquet --user
+pip install pyarrow --user
+
+Potential compression algorithms are gzip (default), snappy, lzo, uncompressed.
+Availability depends on the installation of the engine used.
+
+[2018-10-02: The 'dc2_object_run1.2p reader doesn't exist yet.]
+
+"""
+    parser = ArgumentParser(description=usage,
+                            formatter_class=RawTextHelpFormatter)
+    parser.add_argument('--reader', default='dc2_coadd_run1.1p',
+                        help='GCR reader to use. (default: %(default)s)')
+    parser.add_argument('--parquet_scheme', default='hive',
+                        choices=['hive', 'simple'],
+                        help="""
+Parquet storage scheme. (default: %(default)s)
+'simple': one file.
+'hive': one directory with a metadata file and
+the data partitioned into row groups.""")
+    parser.add_argument('--parquet_engine', default='fastparquet',
+                        choices=['fastparquet', 'pyarrow'],
+                        help="""
+Parquet engine to use. (default: %(default)s)""")
+    parser.add_argument('--parquet_compression', default='gzip',
+                        choices=['gzip', 'snappy', 'lzo', 'uncompressed'],
+                        help="""
+Parquet compression algorithm to use. (default: %(default)s)""")
+    parser.add_argument('--verbose', default=False, action='store_true')
+
+    args = parser.parse_args(sys.argv[1:])
+
+    convert_all_to_dpdd(
+        reader=args.reader,
+        parquet_engine=args.parquet_engine,
+        parquet_compression=args.parquet_compression)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -168,10 +168,7 @@ the data partitioned into row groups.
                         help="""(default: %(default)s)""")
     parser.add_argument('--verbose', default=False, action='store_true')
 
-    args = parser.parse_args(sys.argv[1:])
+    args = parser.parse_args()
+    kwargs = vars(args)
 
-    convert_all_to_parquet(
-        args.reader,
-        parquet_scheme=args.parquet_scheme,
-        parquet_engine=args.parquet_engine,
-        parquet_compression=args.parquet_compression)
+    convert_all_to_parquet(**kwargs)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -106,21 +106,19 @@ def write_dataframe_to_files(
 if __name__ == "__main__":
     from argparse import ArgumentParser, RawTextHelpFormatter
     usage = """
-Produce Parquet output files from GCR catalogs.
+Produce Parquet output file from a GCR catalog.
 
 Example:
 
-To produce files for all data call with:
+To produce an output Parquet file from the 'dc2_object_run1.2p' GCR catalog:
 
-python %(prog)s
+python %(prog)s dc2_object_run1.2p
 
-To specify a different reader
+By default the output name will be 'dc2_object_run1.2p.parquet'.  You could specify a different one on the command line:
 
-python %(prog)s --reader dc2_object_run1.2p
-python %(prog)s --reader dc2_truth_run1.2_static
+python %(prog)s dc2_object_run1.2p --output_filename dc2_object.parquet
 
-You can also specify the engine to use to write parquet files, and the
-compression algorithm to use:
+You can also specify the Parquet scheme, engine, and compression to use.
 
 python %(prog)s
     --parquet_scheme hive
@@ -137,7 +135,7 @@ Availability depends on the installation of the engine used.
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
-    parser.add_argument('reader', help='GCR reader to use.')
+    parser.add_argument('reader', help='GCR catalog to read.')
     parser.add_argument('--output_filename', default=None,
                         help='Output filename')
     parser.add_argument('--include_native', action='store_true', default=False,

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -20,8 +20,8 @@ import pandas as pd
 import GCRCatalogs
 
 
-def convert_all_to_parquet(reader='dc2_coadd_run1.1p', **kwargs):
-    """Produce output files for all available GCR 'reader'.
+def convert_cat_to_parquet(reader='dc2_coadd_run1.1p', include_native=True, **kwargs):
+    """Save columns from input GCR catalog.
 
     Parameters
     ----------
@@ -31,35 +31,17 @@ def convert_all_to_parquet(reader='dc2_coadd_run1.1p', **kwargs):
 
     Other Parameters
     ----------------
-    **kwargs
-        *kwargs* are optional properties writing the dataframe to files.
-        See `write_dataframe_to_files` for more information.
-
-    """
-    cat = GCRCatalogs.load_catalog(reader)
-    # We don't want to use the cache we don't want to use the extra memory
-    # when we know we are just going through the data once.
-    cat.use_cache = False
-
-    convert_cat_to_parquet(cat, **kwargs)
-
-
-def convert_cat_to_parquet(cat, include_native=True, **kwargs):
-    """Save columns from input GCR catalog.
-
-    Parameters
-    ----------
-    cat : GCRCatalog instance
-        Catalog instance returned by `GCRCatalogs.load_catalog`.
-
-    Other Parameters
-    ----------------
     include_native : Include the native quantities from the GCR reader class
                      in addition to the standardized non-native quantities.
     **kwargs
         *kwargs* are optional properties writing the dataframe to files.
         See `write_dataframe_to_files` for more information.
     """
+    cat = GCRCatalogs.load_catalog(reader)
+    # We don't want to use the cache we don't want to use the extra memory
+    # when we know we are just going through the data once.
+    cat.use_cache = False
+
     columns = cat.list_all_quantities(include_native=include_native)
 
     quantities = cat.get_quantities(columns, return_iterator=True)
@@ -171,4 +153,4 @@ the data partitioned into row groups.
     args = parser.parse_args()
     kwargs = vars(args)
 
-    convert_all_to_parquet(**kwargs)
+    convert_cat_to_parquet(**kwargs)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -150,9 +150,9 @@ Availability depends on the installation of the engine used.
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('--reader', help='GCR reader to use.')
     parser.add_argument('--include_native', action='store_true', default=True,
-                        help='Include the native along with the non-native GCR catalog quantities',
+                        help='Include the native along with the non-native GCR catalog quantities')
     parser.add_argument('--exclude_native', dest='include_native', action='store_false',
-                        help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.',
+                        help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.')
     parser.add_argument('--parquet_scheme', default='simple',
                         choices=['hive', 'simple'],
                         help="""'simple': one file.

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -148,7 +148,7 @@ Availability depends on the installation of the engine used.
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
-    parser.add_argument('--reader', help='GCR reader to use.')
+    parser.add_argument('reader', help='GCR reader to use.')
     parser.add_argument('--include_native', action='store_true', default=True,
                         help='Include the native along with the non-native GCR catalog quantities')
     parser.add_argument('--exclude_native', dest='include_native', action='store_false',

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -99,7 +99,7 @@ def write_dataframe_to_files(
         If True, print out debug messages. Default is True.
     """
     # Normalise output filename
-    outfile = '{}.{}'.format(filename_prefix, 'parquet')
+    parquet_file = '{}.{}'.format(filename_prefix, 'parquet')
 
     if verbose:
         print("Writing chunk {} to Parquet file.".format(df))

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -20,7 +20,10 @@ import pandas as pd
 import GCRCatalogs
 
 
-def convert_cat_to_parquet(reader='dc2_coadd_run1.1p', include_native=True, **kwargs):
+def convert_cat_to_parquet(reader='dc2_coadd_run1.1p',
+                           filename_prefix=None,
+                           include_native=True,
+                           **kwargs):
     """Save columns from input GCR catalog.
 
     Parameters
@@ -37,6 +40,9 @@ def convert_cat_to_parquet(reader='dc2_coadd_run1.1p', include_native=True, **kw
         *kwargs* are optional properties writing the dataframe to files.
         See `write_dataframe_to_files` for more information.
     """
+    if filename_prefix is None:
+        filename_prefix = reader
+
     cat = GCRCatalogs.load_catalog(reader)
     # We don't want to use the cache we don't want to use the extra memory
     # when we know we are just going through the data once.
@@ -47,7 +53,9 @@ def convert_cat_to_parquet(reader='dc2_coadd_run1.1p', include_native=True, **kw
     quantities = cat.get_quantities(columns, return_iterator=True)
     for quantities_this_chunk in quantities:
         quantities_this_chunk = pd.DataFrame.from_dict(quantities_this_chunk)
-        write_dataframe_to_files(quantities_this_chunk, **kwargs)
+        write_dataframe_to_files(quantities_this_chunk,
+                                 filename_prefix=filename_prefix,
+                                 **kwargs)
 
 
 def write_dataframe_to_files(

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -20,10 +20,8 @@ import pandas as pd
 import GCRCatalogs
 
 
-def convert_all_to_dpdd(reader='dc2_coadd_run1.1p', **kwargs):
-    """Produce DPDD output files for all available tracts in GCR 'reader'.
-
-    The input filename is expected to match 'trim_merged_tract_.*\.hdf5$'.
+def convert_all_to_parquet(reader='dc2_coadd_run1.1p', **kwargs):
+    """Produce output files for all available GCR 'reader'.
 
     Parameters
     ----------
@@ -43,10 +41,10 @@ def convert_all_to_dpdd(reader='dc2_coadd_run1.1p', **kwargs):
     # when we know we are just going through the data once.
     cat.use_cache = False
 
-    convert_cat_to_dpdd(cat, **kwargs)
+    convert_cat_to_parquet(cat, **kwargs)
 
 
-def convert_cat_to_dpdd(cat, include_native=True, **kwargs):
+def convert_cat_to_parquet(cat, include_native=True, **kwargs):
     """Save columns from input GCR catalog.
 
     Parameters
@@ -145,9 +143,6 @@ pip install pyarrow --user
 
 Potential compression algorithms are gzip (default), snappy, lzo, uncompressed.
 Availability depends on the installation of the engine used.
-
-[2018-10-02: The 'dc2_object_run1.2p reader doesn't exist yet.]
-
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
@@ -170,7 +165,7 @@ the data partitioned into row groups.
 
     args = parser.parse_args(sys.argv[1:])
 
-    convert_all_to_dpdd(
+    convert_cat_to_parquet(
         reader=args.reader,
         parquet_engine=args.parquet_engine,
         parquet_compression=args.parquet_compression)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -146,8 +146,7 @@ Availability depends on the installation of the engine used.
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
-    parser.add_argument('--reader', default='dc2_coadd_run1.1p',
-                        help='GCR reader to use. (default: %(default)s)')
+    parser.add_argument('--reader', help='GCR reader to use.')
     parser.add_argument('--parquet_scheme', default='hive',
                         choices=['hive', 'simple'],
                         help="""'simple': one file.
@@ -165,7 +164,8 @@ the data partitioned into row groups.
 
     args = parser.parse_args(sys.argv[1:])
 
-    convert_cat_to_parquet(
-        reader=args.reader,
+    convert_all_to_parquet(
+        args.reader,
+        parquet_scheme=args.parquet_scheme,
         parquet_engine=args.parquet_engine,
         parquet_compression=args.parquet_compression)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -21,7 +21,7 @@ import GCRCatalogs
 
 
 def convert_cat_to_parquet(reader='dc2_coadd_run1.1p',
-                           filename_prefix=None,
+                           output_filename=None,
                            include_native=True,
                            **kwargs):
     """Save columns from input GCR catalog.
@@ -34,14 +34,16 @@ def convert_cat_to_parquet(reader='dc2_coadd_run1.1p',
 
     Other Parameters
     ----------------
+    output_filename : str, optional
+        If None, then will be constructed as '<reader>.parquet'
     include_native : Include the native quantities from the GCR reader class
                      in addition to the standardized non-native quantities.
     **kwargs
         *kwargs* are optional properties writing the dataframe to files.
         See `write_dataframe_to_files` for more information.
     """
-    if filename_prefix is None:
-        filename_prefix = reader
+    if output_filename is None:
+        output_filename = '{}.{}'.format(reader, 'parquet')
 
     cat = GCRCatalogs.load_catalog(reader)
     # We don't want to use the cache we don't want to use the extra memory
@@ -54,13 +56,13 @@ def convert_cat_to_parquet(reader='dc2_coadd_run1.1p',
     for quantities_this_chunk in quantities:
         quantities_this_chunk = pd.DataFrame.from_dict(quantities_this_chunk)
         write_dataframe_to_files(quantities_this_chunk,
-                                 filename_prefix=filename_prefix,
+                                 output_filename=output_filename,
                                  **kwargs)
 
 
 def write_dataframe_to_files(
         df,
-        filename_prefix='cat',
+        output_filename='cat.parquet',
         parquet_scheme='simple',
         parquet_engine='fastparquet',
         parquet_compression='gzip',
@@ -73,8 +75,8 @@ def write_dataframe_to_files(
     ----------
     df : Pandas DataFrame
         Pandas DataFrame with the input catalog data to write out.
-    filename_prefix : str, optional
-        Prefix to be added to the output filename. Default is 'cat'.
+    output_filename : str, optional
+        Output filename. Default is 'cat.parquet'.
     parquet_scheme : str, optional   ['simple' or 'hive']
             'simple' stores everything in one file per tract
             'hive' stores one directory with a _metadata file and then
@@ -90,14 +92,11 @@ def write_dataframe_to_files(
     verbose : boolean, optional
         If True, print out debug messages. Default is True.
     """
-    # Normalise output filename
-    parquet_file = '{}.{}'.format(filename_prefix, 'parquet')
-
     if verbose:
         print("Writing chunk {} to Parquet file.".format(df))
     # Append iff the file already exists
-    parquet_append = append and os.path.exists(parquet_file)
-    df.to_parquet(parquet_file,
+    parquet_append = append and os.path.exists(output_filename)
+    df.to_parquet(output_filename,
                   append=parquet_append,
                   file_scheme=parquet_scheme,
                   engine=parquet_engine,
@@ -139,6 +138,8 @@ Availability depends on the installation of the engine used.
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('reader', help='GCR reader to use.')
+    parser.add_argument('--output_filename', default=None,
+                        help='Output filename')
     parser.add_argument('--include_native', action='store_true', default=False,
                         help='Include the native along with the non-native GCR catalog quantities')
     parser.add_argument('--exclude_native', dest='include_native', action='store_false',

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -71,7 +71,7 @@ def convert_cat_to_parquet(cat, include_native=True, **kwargs):
 def write_dataframe_to_files(
         df,
         filename_prefix='cat',
-        parquet_scheme='hive',
+        parquet_scheme='simple',
         parquet_engine='fastparquet',
         parquet_compression='gzip',
         append=True,
@@ -153,7 +153,7 @@ Availability depends on the installation of the engine used.
                         help='Include the native along with the non-native GCR catalog quantities',
     parser.add_argument('--exclude_native', dest='include_native', action='store_false',
                         help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.',
-    parser.add_argument('--parquet_scheme', default='hive',
+    parser.add_argument('--parquet_scheme', default='simple',
                         choices=['hive', 'simple'],
                         help="""'simple': one file.
 'hive': one directory with a metadata file and

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -20,17 +20,16 @@ import pandas as pd
 import GCRCatalogs
 
 
-def convert_cat_to_parquet(reader='dc2_coadd_run1.1p',
+def convert_cat_to_parquet(reader,
                            output_filename=None,
-                           include_native=True,
+                           include_native=False,
                            **kwargs):
     """Save columns from input GCR catalog.
 
     Parameters
     ----------
-    reader : str, optional
+    reader : str
         GCR reader to use. Must match an existing yaml file.
-        Default is dc2_coadd_run1.1p
 
     Other Parameters
     ----------------
@@ -140,8 +139,6 @@ Availability depends on the installation of the engine used.
                         help='Output filename')
     parser.add_argument('--include_native', action='store_true', default=False,
                         help='Include the native along with the non-native GCR catalog quantities')
-    parser.add_argument('--exclude_native', dest='include_native', action='store_false',
-                        help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.')
     parser.add_argument('--parquet_scheme', default='simple',
                         choices=['hive', 'simple'],
                         help="""'simple': one file.

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -126,9 +126,10 @@ To produce files for all data call with:
 
 python %(prog)s
 
-To specify a different reader and produce files for all available tracts:
+To specify a different reader
 
 python %(prog)s --reader dc2_object_run1.2p
+python %(prog)s --reader dc2_truth_run1.2_static
 
 You can also specify the engine to use to write parquet files, and the
 compression algorithm to use:

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -149,7 +149,7 @@ Availability depends on the installation of the engine used.
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('reader', help='GCR reader to use.')
-    parser.add_argument('--include_native', action='store_true', default=True,
+    parser.add_argument('--include_native', action='store_true', default=False,
                         help='Include the native along with the non-native GCR catalog quantities')
     parser.add_argument('--exclude_native', dest='include_native', action='store_false',
                         help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.')

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -15,7 +15,6 @@ pyarrow or fastparquet.
 import os
 import sys
 
-from astropy.table import Table
 import pandas as pd
 
 import GCRCatalogs
@@ -156,19 +155,17 @@ Availability depends on the installation of the engine used.
                         help='GCR reader to use. (default: %(default)s)')
     parser.add_argument('--parquet_scheme', default='hive',
                         choices=['hive', 'simple'],
-                        help="""
-Parquet storage scheme. (default: %(default)s)
-'simple': one file.
+                        help="""'simple': one file.
 'hive': one directory with a metadata file and
-the data partitioned into row groups.""")
+the data partitioned into row groups.
+(default: %(default)s)
+""")
     parser.add_argument('--parquet_engine', default='fastparquet',
                         choices=['fastparquet', 'pyarrow'],
-                        help="""
-Parquet engine to use. (default: %(default)s)""")
+                        help="""(default: %(default)s)""")
     parser.add_argument('--parquet_compression', default='gzip',
                         choices=['gzip', 'snappy', 'lzo', 'uncompressed'],
-                        help="""
-Parquet compression algorithm to use. (default: %(default)s)""")
+                        help="""(default: %(default)s)""")
     parser.add_argument('--verbose', default=False, action='store_true')
 
     args = parser.parse_args(sys.argv[1:])

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -54,6 +54,8 @@ def convert_cat_to_parquet(cat, include_native=True, **kwargs):
 
     Other Parameters
     ----------------
+    include_native : Include the native quantities from the GCR reader class
+                     in addition to the standardized non-native quantities.
     **kwargs
         *kwargs* are optional properties writing the dataframe to files.
         See `write_dataframe_to_files` for more information.
@@ -147,6 +149,10 @@ Availability depends on the installation of the engine used.
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('--reader', help='GCR reader to use.')
+    parser.add_argument('--include_native', action='store_true', default=True,
+                        help='Include the native along with the non-native GCR catalog quantities',
+    parser.add_argument('--exclude_native', dest='include_native', action='store_false',
+                        help='Only include non-native GCR catalog quantities.  Exclude purely native quantities.',
     parser.add_argument('--parquet_scheme', default='hive',
                         choices=['hive', 'simple'],
                         help="""'simple': one file.


### PR DESCRIPTION
Adds a simple script `write_gcr_to_parquet.py` that writes out a GCR-readable catalog into a Parquet file.

This script is meant as both a useful utility and a simple example of how to do this.