### PR TITLE
Issues/310

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,7 @@ if [ -n "$DESCPYTHONPATH" ]; then
 fi
 ```
 
+Then run
 ```
 REPO=/global/cscratch1/sd/desc/DC2/data/Run1.2i_globus_in2p3_20181217/w_2018_39/rerun/multiband
 TRACTS="5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429"
@@ -63,7 +64,24 @@ SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
 nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" "${TRACTS}" > merge_tract_cat.log 2>&1 < /dev/null
 ```
 
-2. Generate "Trimmed" Object Tables
+2. Write a `gcr-catalogs` reader for the new catalog.  Generally this will be as easy as creating a new configuration file with a new base_dir and description.  E.g., the catalog config file for Run 1.2i (https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml) is:
+
+```
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
+description: DC2 Run 1.2i Object Catalog
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.2
+```
+
+Note:
+`pixel_scale` above refers to choice of pixel scale for the coadd, not necessarily the native instrument itself.
+Make sure to check the pixel scale used by the sky map to generate the coadds.  
+
+3. Generate "Trimmed" Object Tables
 These files have only the columns necessary to reconstruct the DPDD.
 They maintain their original column names.  
 
@@ -87,7 +105,7 @@ python trim_tract_cat.py WORKING_DIR=/global/projecta/projectdirs/lsst/global/in
 
 This trim step uses the Generic Catalog Reader to determine the columns required in the trim catalog.
 
-3. Generate DPDD-column only Object Tables in Parquet
+4. Generate DPDD-column only Object Tables in Parquet
 Produce stand-alone files with columns named as in the DPDD.
 In addition to renaming columns, this also translates to derived columns that are based on several input columns.
 For speed, this is done by default on the already trimmed object tables (from the step just above).  But it would be possible to do it directly from the full Object merged_tract_cat files instead.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,7 +80,7 @@ mkdir -p "${WORKING_DIR}"
 cd ${WORKING_DIR}
 
 SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
-nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" "${TRACTS}" > merge_tract_cat.log 2>&1 < /dev/null
+nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" ${TRACTS} > merge_tract_cat.log 2>&1 < /dev/null
 ```
 
 ### Trimmed Files

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,9 +111,9 @@ In addition to renaming columns, this also translates to derived columns that ar
 For speed, this is done by default on the already trimmed object tables (from the step just above).  But it would be possible to do it directly from the full Object merged_tract_cat files instead.
 
 ```
-python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.1p
-python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2p
-python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2i
+python convert_merged_tract_to_dpdd.py --reader dc2_object_run1.1p
+python convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2p
+python convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2i
 ```
 
 This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, run the following snippet of code in the relevant `object_catalog` directory:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,43 +21,79 @@ python merged_tract_cat.py ${REPO} 4429
 
 While they are hitting the same filesystem, they are not hitting the same files.
 
-In theory, running this for Run 1.2p should be as easy as:
+The Run 1.2p files were generated with
 
 ```
 REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/w_2018_30/rerun/coadd-test5-u
 python merged_tract_cat.py ${REPO} [...]
 ```
 
-Where you'll have to look up what the tracts are for Run 1.2.
-
-Except that probably won't be the exact name of the DM output repository.  You'll want the output rerun of the final coadd photometry.
-
-* Once these are generated, to read them with GCR one would have to write a very lightly updated reader for GCR catalogs.  But it ideally should even work by just specifying a different root path to the same GCR reader.
+The Run 1.2i files were generated with by setting up a shifter image:
 
 ```
-config = {'base_dir': '/global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog'}
-GCRCatalogs.load_catalog('dc2_coadd_run1.1p', config)
+shifter --image=lsstdesc/stack-jupyter:prod
+```
+
+Then executing the relevant config file
+
+```
+source /opt/lsst/software/stack/loadLSST.bash ""
+setup lsst_distrib
+setup -r /opt/lsst/software/stack/obs_lsstCam
+setup lsst_sims
+export OMP_NUM_THREADS=1
+
+export PYTHONNOUSERSITE=' '
+
+if [ -n "$DESCPYTHONPATH" ]; then
+    export PYTHONPATH="$DESCPYTHONPATH:$PYTHONPATH"
+    echo "Including user python path: $DESCPYTHONPATH"
+fi
+```
+
+```
+REPO=/global/cscratch1/sd/desc/DC2/data/Run1.2i_globus_in2p3_20181217/w_2018_39/rerun/multiband
+TRACTS="5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429"
+
+WORKING_DIR=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
+mkdir -p "${WORKING_DIR}"
+cd ${WORKING_DIR}
+
+SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
+nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" "${TRACTS}" > merge_tract_cat.log 2>&1 < /dev/null
 ```
 
 2. Generate "Trimmed" Object Tables
 These files have only the columns necessary to reconstruct the DPDD.
 They maintain their original column names.  
 
-The Run 1.1p Object trimmed object tables were generated with
+The respective Object trimmed object tables were generated with
 
+Run 1.1p
 ```
 python trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.1/object_catalog/merged_tract_cat_*.hdf5
 ```
 
-This operates directly on the HDF5 files, with no dependence on the Generic Catalog Reader or the DM Stack.
+Run 1.2p
+```
+python trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog/merged_tract_cat_*.hdf5
+```
 
-3. Generate DPDD-column only Object Tables in HDF, FITS, and Parquet
+Run 1.2i
+```
+python trim_tract_cat.py WORKING_DIR=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new/object_tract_*.hdf5
+```
+(Note that the output HDF5 files are named `object_tract_*` instead of `merged_tract_*` as they were for Run 1.1p and 1.2p)
+
+This trim step uses the Generic Catalog Reader to determine the columns required in the trim catalog.
+
+3. Generate DPDD-column only Object Tables in Parquet
 Produce stand-alone files with columns named as in the DPDD.
 In addition to renaming columns, this also translates to derived columns that are based on several input columns.
 For speed, this is done by default on the already trimmed object tables (from the step just above).  But it would be possible to do it directly from the full Object merged_tract_cat files instead.
 
 ```
 python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.1p
+python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2p
+python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2i
 ```
-
-Will generate these files for all tracts available through the `dc2_coadd_run1.1p` reader. 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@ General scripts need for tasks related to the DC2 production and
 validation can be put in this directory.
 
 ## How To Generate Object Tables from DM processing outputs
-*by Michael Wood-Vasey <wmwv>*
+*by Michael Wood-Vasey [@wmwv]*
 
 ### Environment configuration
 #### Shifter image of DM+DESC environment

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,50 +1,25 @@
 General scripts need for tasks related to the DC2 production and
 validation can be put in this directory.
 
-### How To Generate Object Tables from DM processing outputs
-The commands run here are from the `DC2-Production/scripts` directory.  The notes in this file using a `SCRIPT_DIR` environment variable to point to this location.  I ran these as I was developing the scripts, so my `SCRIPT_DIR` points to my local checkout:
+## How To Generate Object Tables from DM processing outputs
+*by Michael Wood-Vasey <wmwv>*
 
-```
-SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
-```
+### Environment configuration
+#### Shifter image of DM+DESC environment
+I used the same shifter image DESC uses for the NERSC Jupyter Hub `desc-stack` kernel.  I ran `shifter` from the command line
 
-1. The Run 1.1p Object table summary files were generated with
-
-```
-REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.1/output
-python ${SCRIPT_DIR}/merged_tract_cat.py ${REPO} 5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429
-
-
-```
-
-It took many hours.
-This can be trivially parallelized with one invocation per tract.  E.g.,
-
-```
-python ${SCRIPT_DIR}/merged_tract_cat.py ${REPO} 5066
-python ${SCRIPT_DIR}/merged_tract_cat.py ${REPO} 5065
-...
-python merged_tract_cat.py ${REPO} 4429
-```
-
-While they are hitting the same filesystem, they are not hitting the same files.
-
-The Run 1.2p files were generated with
-
-```
-REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/w_2018_30/rerun/coadd-test5-u
-python merged_tract_cat.py ${REPO} [...]
-```
-
-The Run 1.2i files were generated with by setting up a shifter image:
-
-```
+```bash
 shifter --image=lsstdesc/stack-jupyter:prod
 ```
 
-Then executing the relevant config file
-
+and then ran the configuration and subsequent lines below from that the shifter session.
+```bash
+. setup_shifter_env.sh
 ```
+
+Which contains
+
+```bash
 source /opt/lsst/software/stack/loadLSST.bash ""
 setup lsst_distrib
 setup -r /opt/lsst/software/stack/obs_lsstCam
@@ -59,8 +34,44 @@ if [ -n "$DESCPYTHONPATH" ]; then
 fi
 ```
 
-Then run
+
+#### Script directory
+The commands run here are from the `DC2-Production/scripts` directory.  The notes in this file using a `SCRIPT_DIR` environment variable to point to this location.  I ran these as I was developing the scripts, so my `SCRIPT_DIR` points to my local checkout:
+
+```bash
+SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
 ```
+
+### Summary Files
+
+#### Run 1.1p
+
+```bash
+REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.1/output
+python "${SCRIPT_DIR}"/merged_tract_cat.py ${REPO} 5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429
+```
+
+It took many hours.
+This can be trivially parallelized with one invocation per tract.  E.g.,
+
+```bash
+python "${SCRIPT_DIR}"/merged_tract_cat.py ${REPO} 5066
+python "${SCRIPT_DIR}"/merged_tract_cat.py ${REPO} 5065
+...
+python "${SCRIPT_DIR}"/merged_tract_cat.py ${REPO} 4429
+```
+
+While they are hitting the same filesystem, they are not hitting the same files.
+
+#### Run 1.2p
+
+```bash
+REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/w_2018_30/rerun/coadd-test5-u
+python "${SCRIPT_DIR}"/merged_tract_cat.py ${REPO} [...]
+```
+
+Then run
+```bash
 REPO=/global/cscratch1/sd/desc/DC2/data/Run1.2i_globus_in2p3_20181217/w_2018_39/rerun/multiband
 TRACTS="5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429"
 
@@ -72,9 +83,38 @@ SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
 nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" "${TRACTS}" > merge_tract_cat.log 2>&1 < /dev/null
 ```
 
-2. Write a `gcr-catalogs` reader for the new catalog.  Generally this will be as easy as creating a new configuration file with a new base_dir and description.  E.g., the catalog config file for Run 1.2i (https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml) is:
+### Trimmed Files
 
+Generate "Trimmed" Object Tables
+These files have only the columns necessary to reconstruct the DPDD.
+They maintain their original column names.  
+
+The respective Object trimmed object tables were generated with
+
+Run 1.1p
+```bash
+python  "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.1/object_catalog/merged_tract_cat_*.hdf5
 ```
+
+Run 1.2p
+```bash
+python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog/merged_tract_cat_*.hdf5
+```
+
+Run 1.2i
+```bash
+python "${SCRIPT_DIR}"/trim_tract_cat.py WORKING_DIR=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new/object_tract_*.hdf5
+```
+(Note that the output HDF5 files are named `object_tract_*` instead of `merged_tract_*` as they were for Run 1.1p and 1.2p)
+
+This trim step uses the Generic Catalog Reader to determine the columns required in the trim catalog.  We can do this before generating the actual catalog reader configuration file because the basic quantities we need are constant across the DC2 Runs.
+
+
+### Update gcr-catalog
+
+Write a `gcr-catalogs` reader for the new catalog.  Generally this will be as easy as creating a new configuration file with a new base_dir and description.  E.g., the catalog config file for Run 1.2i (https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml) is:
+
+```yaml
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
 schema_filename: trim_schema.yaml
@@ -87,45 +127,23 @@ pixel_scale: 0.2
 
 Note:
 `pixel_scale` above refers to choice of pixel scale for the coadd, not necessarily the native instrument itself.
-Make sure to check the pixel scale used by the sky map to generate the coadds.  
+Make sure to check the pixel scale used by the sky map to generate the coadds.
 
-3. Generate "Trimmed" Object Tables
-These files have only the columns necessary to reconstruct the DPDD.
-They maintain their original column names.  
+#### DPDD Parquet files
 
-The respective Object trimmed object tables were generated with
-
-Run 1.1p
-```
-python trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.1/object_catalog/merged_tract_cat_*.hdf5
-```
-
-Run 1.2p
-```
-python ${SCRIPT_DIR}/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog/merged_tract_cat_*.hdf5
-```
-
-Run 1.2i
-```
-python trim_tract_cat.py WORKING_DIR=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new/object_tract_*.hdf5
-```
-(Note that the output HDF5 files are named `object_tract_*` instead of `merged_tract_*` as they were for Run 1.1p and 1.2p)
-
-This trim step uses the Generic Catalog Reader to determine the columns required in the trim catalog.
-
-4. Generate DPDD-column only Object Tables in Parquet
 Produce stand-alone files with columns named as in the DPDD.
+
 In addition to renaming columns, this also translates to derived columns that are based on several input columns.
 For speed, this is done by default on the already trimmed object tables (from the step just above).  But it would be possible to do it directly from the full Object merged_tract_cat files instead.
 
-```
-python ${SCRIPT_DIR}/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.1p
-python ${SCRIPT_DIR}/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2p
-python ${SCRIPT_DIR}/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2i
+```bash
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.1p
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2p
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2i
 ```
 
 This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, run the following in the relevant `object_catalog` directory:
 
-```
-python ${SCRIPT_DIR}/merge_parquet_files.py dpdd_object_tract_????.parquet
+```bash
+python "${SCRIPT_DIR}"/merge_parquet_files.py dpdd_object_tract_????.parquet
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,3 +115,31 @@ python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.1p
 python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2p
 python convert_merged_tract_to_dpdd.py --reader dc2_coadd_run1.2i
 ```
+
+This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, run the following snippet of code in the relevant `object_catalog` directory:
+
+```
+import pandas as pd
+
+file_prefix = 'dpdd_object_tract_'
+file_suffix = 'parquet'
+
+out_file = 'dpdd_object.parquet'
+
+tracts = [4429, 4430, 4431, 4432, 4433, 4636, 4637, 4638, 4639, 4640, 4848, 4849, 4850, 4851, 4852, 5062, 5063, 5064, 5065, 5066]
+
+# Write with append for Parquet is not supported as of Pandas 0.23
+# So we build up a dataframe from all tracts and then write once
+df = None
+for tract in tracts:
+    data_file = '{}{:d}.{}'.format(file_prefix, tract, file_suffix)
+    print("Reading {}".format(data_file))
+    this_df = pd.read_parquet(data_file)
+    if df is None:
+        df = this_df
+    else:
+        df = df.append(this_df)
+
+df.to_parquet(out_file)
+```
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,6 +34,11 @@ if [ -n "$DESCPYTHONPATH" ]; then
 fi
 ```
 
+Although it's not what I used to re-generate Run 1.2i, another way of accomplishing this same setup would be to use the `start-kernel-cli.py` program in `https://github.com/LSSTDESC/nersc`.
+
+```
+python start-kernel-cli.py desc-stack
+```
 
 #### Script directory
 The commands run here are from the `DC2-Production/scripts` directory.  The notes in this file using a `SCRIPT_DIR` environment variable to point to this location.  I ran these as I was developing the scripts, so my `SCRIPT_DIR` points to my local checkout:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -129,6 +129,24 @@ Note:
 `pixel_scale` above refers to choice of pixel scale for the coadd, not necessarily the native instrument itself.
 Make sure to check the pixel scale used by the sky map to generate the coadds.
 
+#### Generate Schema files
+
+To save load time, we generate a schema file that tells the GCRCatalog exactly what's in the file.
+We can generate this the first time with:
+
+```python
+import GCRCatalogs
+
+for cat in ('dc2_object_run1.2i', 'dc2_object_run1.2i_all_columns'):
+    GCRCatalogs.load_catalog(cat).generate_schema_yaml()
+```
+
+When given no schema the reader goes through and figures out all of the available columns.
+The schema file is then saved to the same base directory as the catalog files.
+If the schema file already exists it won't be overwritten.
+
+After the schema file is created will be picked up by the reader and loading should be much faster.
+
 #### DPDD Parquet files
 
 Produce stand-alone files with columns named as in the DPDD.

--- a/scripts/make_run1p2i_merge_tract_cats.sh
+++ b/scripts/make_run1p2i_merge_tract_cats.sh
@@ -1,0 +1,22 @@
+# 2019-01-15 Michael Wood-Vasey
+#
+# Use 
+# shifter --image=lsstdesc/stack-jupyter:prod
+# I don't know how to more specifically control the version of the shifter image
+# . /global/common/software/lsst/common/miniconda/kernels/stack-prod.sh
+
+. setup_shifter_env.sh
+ 
+# On NERSC
+REPO=/global/cscratch1/sd/desc/DC2/data/Run1.2i_globus_in2p3_20181217/w_2018_39/rerun/multiband
+TRACTS="5066 5065 5064 5063 5062 4852 4851 4850 4849 4848 4640 4639 4638 4637 4636 4433 4432 4431 4430 4429"
+
+WORKING_DIR=/global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
+mkdir -p "${WORKING_DIR}"
+cd ${WORKING_DIR}
+
+SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
+# These weren't actually run this way in one list.
+# I instead ran each TRACT one-by-one on a head node.
+# These "should" be done through SLURM.  But given the long queue times it's not clearly faster to do so.
+nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" "${TRACTS}" > merge_tract_cat.log 2>&1 < /dev/null 

--- a/scripts/merge_parquet_files.py
+++ b/scripts/merge_parquet_files.py
@@ -1,0 +1,27 @@
+import sys
+
+import pandas as pd
+
+# Write with append for Parquet is not supported as of Pandas 0.23
+# So we build up a dataframe from all tracts and then write once
+
+def load_files_into_dataframe(parquet_files):
+    df = None
+    for data_file in parquet_files:
+        this_df = pd.read_parquet(data_file)
+        if df is None:
+            df = this_df
+        else:
+            df = df.append(this_df)
+
+    return df
+
+
+def run(input_files, output_file='dpdd_object.parquet'):
+    df = load_files_into_dataframe(input_files)
+    df.to_parquet(output_file)
+
+
+if __name__ == "__main__":
+    input_files = sys.argv[1:]
+    run(input_files)

--- a/scripts/setup_shifter_env.sh
+++ b/scripts/setup_shifter_env.sh
@@ -1,0 +1,15 @@
+# 2019-01-15 Michael Wood-Vasey
+# The setup to run inside the shifter image when running
+# The Jupyter DESC DM stack kernel from the command line.
+source /opt/lsst/software/stack/loadLSST.bash ""
+setup lsst_distrib
+setup -r /opt/lsst/software/stack/obs_lsstCam
+setup lsst_sims
+export OMP_NUM_THREADS=1
+
+export PYTHONNOUSERSITE=' '
+
+if [ -n "$DESCPYTHONPATH" ]; then
+    export PYTHONPATH="$DESCPYTHONPATH:$PYTHONPATH"
+    echo "Including user python path: $DESCPYTHONPATH"
+fi


### PR DESCRIPTION
Adds Run 1.2i Object catalogs along with simple scripts to document in detail.
Parquet file DPDD files (simple format, one file for all tracts) for Run 1.2i and 1.2p.
Documents how they were generated.