### PR TITLE
Issues/317

### DIFF
--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -263,29 +263,6 @@ def trim_long_colnames(cat):
                 cat.rename_column(col_name, new_col_name)
 
 
-def prefix_columns_astropy(cat, filt, fields_to_skip=()):
-    """Prefix the columns of an AstroPy Table with the filter name.
-
-    >>> from astropy.table import Table
-    >>> tab = Table([['a', 'b'], [1, 2]], names=('letter', 'number'))
-    >>> prefix_columns(tab, 'filter')
-    >>> print(tab)
-    filter_letter filter_number
-    ------------- -------------
-                a             1
-                b             2
-
-    """
-    old_colnames = cat.colnames
-    for field in fields_to_skip:
-        field_idx = old_colnames.index(field)
-        old_colnames.pop(field_idx)
-
-    new_colnames = ['%s_%s' % (filt, col) for col in old_colnames]
-    for oc, nc in zip(old_colnames, new_colnames):
-        cat.rename_column(oc, nc)
-
-
 def prefix_columns(cat, filt, fields_to_skip=()):
     """Prefix the columns of an Pandas DataFrame with the filter name.
 

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -177,7 +177,6 @@ def load_patch(butler_or_repo, tract, patch,
             print(" ", e)
         return Table()
 
-
     isPrimary = ref_table['detect_isPrimary']
     ref_table = ref_table[isPrimary]
     if len(ref_table) == 0:
@@ -186,12 +185,18 @@ def load_patch(butler_or_repo, tract, patch,
         return ref_table
 
     flux_field_names_per_schema_version = {
-        1: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxSigma',
-              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxSigma'},
-        2: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxErr',
-              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxErr'},
-        3: {'psf_flux': 'base_PsfFlux_instFlux', 'psf_flux_err': 'base_PsfFlux_instFluxErr',
-              'modelfit_flux': 'modelfit_CModel_instFlux', 'modelfit_flux_err': 'modelfit_CModel_instFluxErr'},
+        1: {'psf_flux': 'base_PsfFlux_flux',
+            'psf_flux_err': 'base_PsfFlux_fluxSigma',
+            'modelfit_flux': 'modelfit_CModel_flux',
+            'modelfit_flux_err': 'modelfit_CModel_fluxSigma'},
+        2: {'psf_flux': 'base_PsfFlux_flux',
+            'psf_flux_err': 'base_PsfFlux_fluxErr',
+            'modelfit_flux': 'modelfit_CModel_flux',
+            'modelfit_flux_err': 'modelfit_CModel_fluxErr'},
+        3: {'psf_flux': 'base_PsfFlux_instFlux',
+            'psf_flux_err': 'base_PsfFlux_instFluxErr',
+            'modelfit_flux': 'modelfit_CModel_instFlux',
+            'modelfit_flux_err': 'modelfit_CModel_instFluxErr'},
     }
 
     merge_filter_cats = {}

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -100,7 +100,7 @@ def load_and_save_tract(repo, tract, filename, key_prefix='coadd', patches=None,
 
         key = '%s_%d_%s' % (key_prefix, tract, patch)
         key = valid_identifier_name(key)
-#        patch_merged_cat.to_pandas().to_hdf(filename, key, format='fixed')
+        patch_merged_cat.to_hdf(filename, key, format='fixed')
 
 
 def load_tract(repo, tract, patches=None, **kwargs):

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -325,6 +325,11 @@ if __name__ == '__main__':
                         help='Filepath to LSST DM Stack Butler repository.')
     parser.add_argument('tract', type=int, nargs='+',
                         help='Skymap tract[s] to process.')
+    parser.add_argument('--patches', nargs='+',
+                        help='''
+Skymap patch[es] within each tract to process.
+A common use-case for this option is quick testing.
+''')
     parser.add_argument('--name', default='object',
                         help='Base name of files: <name>_tract_5062.hdf5')
     parser.add_argument('--verbose', dest='verbose', default=True,
@@ -344,5 +349,6 @@ if __name__ == '__main__':
     for tract in args.tract:
         filebase = '{:s}_tract_{:d}'.format(args.name, tract)
         filename = filebase + '.hdf5'
-        load_and_save_tract(args.repo, tract, filename, verbose=args.verbose,
+        load_and_save_tract(args.repo, tract, filename,
+                            patches=args.patches, verbose=args.verbose,
                             filters=filters)

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -99,7 +99,7 @@ def load_and_save_tract(repo, tract, filename, key_prefix='coadd', patches=None,
 
         key = '%s_%d_%s' % (key_prefix, tract, patch)
         key = valid_identifier_name(key)
-        patch_merged_cat.to_pandas().to_hdf(filename, key, format='fixed')
+#        patch_merged_cat.to_pandas().to_hdf(filename, key, format='fixed')
 
 
 def load_tract(repo, tract, patches=None, **kwargs):
@@ -177,6 +177,7 @@ def load_patch(butler_or_repo, tract, patch,
             print(" ", e)
         return Table()
 
+
     isPrimary = ref_table['detect_isPrimary']
     ref_table = ref_table[isPrimary]
     if len(ref_table) == 0:
@@ -185,18 +186,12 @@ def load_patch(butler_or_repo, tract, patch,
         return ref_table
 
     flux_field_names_per_schema_version = {
-        1: {'psf_flux': 'base_PsfFlux_flux',
-            'psf_flux_err': 'base_PsfFlux_fluxSigma',
-            'modelfit_flux': 'modelfit_CModel_flux',
-            'modelfit_flux_err': 'modelfit_CModel_fluxSigma'},
-        2: {'psf_flux': 'base_PsfFlux_flux',
-            'psf_flux_err': 'base_PsfFlux_fluxErr',
-            'modelfit_flux': 'modelfit_CModel_flux',
-            'modelfit_flux_err': 'modelfit_CModel_fluxErr'},
-        3: {'psf_flux': 'base_PsfFlux_instFlux',
-            'psf_flux_err': 'base_PsfFlux_instFluxErr',
-            'modelfit_flux': 'modelfit_CModel_instFlux',
-            'modelfit_flux_err': 'modelfit_CModel_instFluxErr'},
+        1: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxSigma',
+              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxSigma'},
+        2: {'psf_flux': 'base_PsfFlux_flux', 'psf_flux_err': 'base_PsfFlux_fluxErr',
+              'modelfit_flux': 'modelfit_CModel_flux', 'modelfit_flux_err': 'modelfit_CModel_fluxErr'},
+        3: {'psf_flux': 'base_PsfFlux_instFlux', 'psf_flux_err': 'base_PsfFlux_instFluxErr',
+              'modelfit_flux': 'modelfit_CModel_instFlux', 'modelfit_flux_err': 'modelfit_CModel_instFluxErr'},
     }
 
     merge_filter_cats = {}
@@ -253,8 +248,8 @@ def load_patch(butler_or_repo, tract, patch,
         # Rename duplicate columns with prefix of filter
         prefix_columns(cat, filt, fields_to_skip=fields_to_join)
         # Merge metadata with concatenation
-        with enable_merge_strategies(MergeNumbersAsList, MergeListNumbersAsList):
-            merged_patch_cat = join(merged_patch_cat, cat, keys=fields_to_join)
+#        with enable_merge_strategies(MergeNumbersAsList, MergeListNumbersAsList):
+#            merged_patch_cat = join(merged_patch_cat, cat, keys=fields_to_join)
 
     if trim_colnames_for_fits:
         # FITS column names can't be longer that 68 characters


### PR DESCRIPTION
Using Pandas instead of AstroPy to join across filters speeds up AFW->HDF5 conversion by a factor of ~8 when testing on one patch (tract: 5066, patch='3,0').

A tract (5066) with 31 filled-in patches took 15 minutes instead of 2-4 hours.

The new method produces an HDF file of the exact same size as the previous now.  I'll do explicit validation over the next few days.