### PR TITLE
Issues/322

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -217,8 +217,8 @@ python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.
 python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2i
 ```
 
-This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, run the following in the relevant `object_catalog` directory:
+This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, use the very simple `merge_parquet_files.py` utility.  E.g.,
 
 ```bash
-python "${SCRIPT_DIR}"/merge_parquet_files.py dpdd_object_tract_????.parquet
+python "${SCRIPT_DIR}"/merge_parquet_files.py dpdd_object_tract_????.parquet --output_file dpdd_object_run1.2i.parquet
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -220,5 +220,5 @@ python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.
 This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, use the very simple `merge_parquet_files.py` utility.  E.g.,
 
 ```bash
-python "${SCRIPT_DIR}"/merge_parquet_files.py dpdd_object_tract_????.parquet --output_file dpdd_object_run1.2i.parquet
+python "${SCRIPT_DIR}"/merge_parquet_files.py dpdd_object_tract_????.parquet --output_file dpdd_dc2_object_run1.2i.parquet
 ```

--- a/scripts/convert_merged_tract_to_dpdd.py
+++ b/scripts/convert_merged_tract_to_dpdd.py
@@ -62,6 +62,7 @@ def convert_cat_to_dpdd(reader='dc2_object_run1.1p',
 def write_dataframe_to_files(
         df,
         filename_prefix='dpdd_object',
+        output_dir='./',
         hdf_key_prefix='object',
         parquet_scheme='simple',
         parquet_engine='fastparquet',
@@ -108,9 +109,9 @@ def write_dataframe_to_files(
     patch = patch.replace(',', '')  # Convert '0,1'->'01'
 
     # Normalize output filename
-    outfile_base_tract_format = '{base}_tract_{tract:04d}'
+    outfile_base_tract_format = os.path.join(output_dir, '{base}_tract_{tract:04d}')
     outfile_base_tract_patch_format = \
-        '{base}_tract_{tract:04d}_patch_{patch:s}'
+        os.path.join(output_dir, '{base}_tract_{tract:04d}_patch_{patch:s}')
 
     # tract is an int
     # but patch is a string (e.g., '01' for '0,1')
@@ -197,10 +198,12 @@ Availability depends on the installation of the engine used.
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
+    parser.add_argument('reader', default='dc2_object_run1.1p',
+                        help='GCR reader to use. (default: %(default)s)')
     parser.add_argument('--tract', type=int, nargs='+', default=[],
                         help='Skymap tract[s] to process.')
-    parser.add_argument('--reader', default='dc2_object_run1.1p',
-                        help='GCR reader to use. (default: %(default)s)')
+    parser.add_argument('--output_dir', default='./',
+                        help='Output directory. (default: %(default)s)')
     parser.add_argument('--write', nargs='+', default=['parquet'],
                         choices=['all', 'hdf', 'fits', 'parquet'],
                         help='Formats to write out. (default: %(default)s)')

--- a/scripts/merge_parquet_files.py
+++ b/scripts/merge_parquet_files.py
@@ -48,5 +48,5 @@ if __name__ == "__main__":
     parser.add_argument('--output_file', default='dpdd_object.parquet',
                         help='Output filepath. (default: %(default)s)')
 
-    args = parser(sys.argv[1:])
+    args = parser.parse_args(sys.argv[1:])
     run(input_files=args.input_files)

--- a/scripts/merge_parquet_files.py
+++ b/scripts/merge_parquet_files.py
@@ -23,5 +23,30 @@ def run(input_files, output_file='dpdd_object.parquet'):
 
 
 if __name__ == "__main__":
-    input_files = sys.argv[1:]
-    run(input_files)
+    from argparse import ArgumentParser, RawTextHelpFormatter
+    usage = """
+    Merge set of parquet files into one Parquet file.
+    The schema must agree.
+
+    Examples
+    --
+    python %(prog)s dpdd_object_*.parquet
+
+    Will take the glob of `dpdd_object_*.parquet` file in the current directory
+    and write an output file `dpdd_object.parquet`.
+
+    python %(prog)s foo/dpdd_object_*.parquet --output_file bar/dpdd.parquet
+
+    will take the glob of `foo/dpdd_object_*.parquet` and write an output file
+    `bar/dpdd.parquet`.
+    """
+
+    parser = ArgumentParser(description=usage,
+                            formatter_class=RawTextHelpFormatter)
+    parser.add_argument('input_files', type=str, nargs='+', default=[],
+                        help='Space-separated list of Parquet files to merge.')
+    parser.add_argument('--output_file', default='dpdd_object.parquet',
+                        help='Output filepath. (default: %(default)s)')
+
+    args = parser(sys.argv[1:])
+    run(input_files=args.input_files)

--- a/scripts/merge_parquet_files.py
+++ b/scripts/merge_parquet_files.py
@@ -49,4 +49,4 @@ if __name__ == "__main__":
                         help='Output filepath. (default: %(default)s)')
 
     args = parser.parse_args(sys.argv[1:])
-    run(input_files=args.input_files)
+    run(input_files=args.input_files, output_file=args.output_file)

--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 
@@ -310,6 +311,8 @@ A common use-case for this option is quick testing.
 ''')
     parser.add_argument('--name', default='object',
                         help='Base name of files: <name>_tract_5062.hdf5')
+    parser.add_argument('--output_dir', default='./',
+                        help='Output directory.  (default: %(default)s)')
     parser.add_argument('--verbose', dest='verbose', default=True,
                         action='store_true', help='Verbose mode.')
     parser.add_argument('--silent', dest='verbose', action='store_false',
@@ -326,7 +329,7 @@ A common use-case for this option is quick testing.
 
     for tract in args.tract:
         filebase = '{:s}_tract_{:d}'.format(args.name, tract)
-        filename = filebase + '.hdf5'
+        filename = os.path.join(args.output_dir, filebase + '.hdf5')
         load_and_save_tract(args.repo, tract, filename,
                             patches=args.patches, verbose=args.verbose,
                             filters=filters)

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -29,8 +29,10 @@ class DummyDC2ObjectCatalog(BaseGenericCatalog):
 
 def load_trim_save_patch(outfile, infile_handle, key, columns_to_keep):
     df = infile_handle.get_storer(key).read()
-    if not columns_to_keep.issubset(df.columns):
+    missing_columns = columns_to_keep.difference(df.columns)
+    if missing_columns:
         warnings.warn('Not all columns to keep are present in the data file.')
+        print('Missing columns are: %s' % missing_columns)
     columns_to_keep_present = list(columns_to_keep.intersection(df.columns))
     trim_df = df[columns_to_keep_present]
     trim_df.to_hdf(outfile, key=key)


### PR DESCRIPTION
Adds `--output_dir` or `--output_file` options, as appropriate, to the scripts that merged the coadd catalogs, generated trim catalogs, and the DPDD Parquet files.