### PR TITLE
Issues/355 - Produce trim versions of Run 2.1i DR1 Object Table

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,7 +173,7 @@ python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/produ
 
 Run 2.1i dr1b
 ```bash
-python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1\:coadd-dr1b-v1/object_table_summary/object_tract_*.hdf5
+python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1\:coadd-dr1b-v1/object_table_summary/object_tract_*.hdf5
 ```
 
 ### Update gcr-catalog

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -223,9 +223,10 @@ In addition to renaming columns, this also translates to derived columns that ar
 For speed, this is done by default on the already trimmed object tables (from the step just above).  But it would be possible to do it directly from the full Object merged_tract_cat files instead.
 
 ```bash
-python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.1p
-python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2p
-python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py --reader dc2_object_run1.2i
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py dc2_object_run1.1p
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py dc2_object_run1.2p
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py dc2_object_run1.2i
+python "${SCRIPT_DIR}"/convert_merged_tract_to_dpdd.py dc2_object_run2.1i
 ```
 
 This will create individual per-tract Parquet files.  To create a merged Parquet file of all tracts, use the very simple `merge_parquet_files.py` utility.  E.g.,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,8 @@ SCRIPT_DIR=/global/homes/w/wmwv/local/lsst/DC2-production/scripts
 nohup python "${SCRIPT_DIR}"/merge_tract_cat.py "${REPO}" ${TRACTS} > merge_tract_cat_${TRACT}.log 2>&1 < /dev/null
 ```
 
+* Starting with Run 2.1i, the Object Tables were generated as part of the processing pipeline.
+
 ### Make Trimmed Files
 
 Generate "Trimmed" Object Tables
@@ -161,9 +163,18 @@ This trim step uses the Generic Catalog Reader to determine the columns required
 
 Run 1.2p v4
 ```bash
-python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4/object_tract_cat_*.hdf5
+python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4/object_tract_*.hdf5
 ```
 
+Run 2.1i dr1a
+```bash
+python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-v1/object_table_summary/object_tract_*.hdf5
+```
+
+Run 2.1i dr1b
+```bash
+python "${SCRIPT_DIR}"/trim_tract_cat.py /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1\:coadd-dr1b-v1/object_table_summary/object_tract_*.hdf5
+```
 
 ### Update gcr-catalog
 

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -110,7 +110,7 @@ v3: '_instFlux', '_instFluxError'
 """)
     parser.add_argument('--output_dir', default='./',
                         help='Output directory.  (default: %(default)s))')
-    parser.add_argument('--verbose', default=False, action='store_true')
+    parser.add_argument('--verbose', action='store_true')
 
     args = parser.parse_args(sys.argv[1:])
     for infile in args.input_files:

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -64,6 +64,10 @@ def make_trim_file(infile, output_file=None, output_dir=None,
                 print("Key: ", key)
             if not re.match(GROUP_PATTERN, key.lstrip('/')):
                 continue
+            # TODO  MWV: 2019-07-05:  Fix this by one of:
+            #   1. Identify cause in original encoding.
+            #   2. Identify why GCR doesn't suffer from this issue (different HDF5 access approach)
+            #   3. When we switch to Parquet files make sure this UnicodeDecodeError problem goes away.
             try:
                 load_trim_save_patch(output_file, fh, key, columns_to_keep)
             except UnicodeDecodeError as e:

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -58,11 +58,18 @@ def make_trim_file(infile, output_file=None, output_dir=None,
     patches = []
     if verbose:
         print("Reading: ", infile)
-    with pd.HDFStore(infile, 'r') as fh:
+    with pd.HDFStore(infile, 'r', errors='replace') as fh:
         for key in fh:
+            if verbose:
+                print("Key: ", key)
             if not re.match(GROUP_PATTERN, key.lstrip('/')):
                 continue
-            load_trim_save_patch(output_file, fh, key, columns_to_keep)
+            try:
+                load_trim_save_patch(output_file, fh, key, columns_to_keep)
+            except UnicodeDecodeError as e:
+                print(e)
+                print(f'Unicode Decoding Error in {output_file} {key}.  Skipping')
+
             patches.append(key.rpartition('_')[-1])
 
     if check_all_patches_exist:

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -40,7 +40,8 @@ def load_trim_save_patch(outfile, infile_handle, key, columns_to_keep):
 
 def make_trim_file(infile, output_file=None, output_dir=None,
                    clobber=True, schema_version=None,
-                   check_all_patches_exist=False):
+                   check_all_patches_exist=False,
+                   verbose=False):
 
     if output_file is None:
         if output_dir is None:
@@ -55,6 +56,8 @@ def make_trim_file(infile, output_file=None, output_dir=None,
     columns_to_keep = DummyDC2ObjectCatalog(schema_version).required_native_quantities
 
     patches = []
+    if verbose:
+        print("Reading: ", infile)
     with pd.HDFStore(infile, 'r') as fh:
         for key in fh:
             if not re.match(GROUP_PATTERN, key.lstrip('/')):
@@ -96,9 +99,11 @@ v3: '_instFlux', '_instFluxError'
 """)
     parser.add_argument('--output_dir', default='./',
                         help='Output directory.  (default: %(default)s))')
+    parser.add_argument('--verbose', default=False, action='store_true')
 
     args = parser.parse_args(sys.argv[1:])
     for infile in args.input_files:
         make_trim_file(infile,
                        schema_version=args.schema_version,
-                       output_dir=args.output_dir)
+                       output_dir=args.output_dir,
+                       verbose=args.verbose)

--- a/scripts/trim_tract_cat.py
+++ b/scripts/trim_tract_cat.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('input_files', type=str, nargs='+', default=[],
                         help='Input HDF5 files to be trimmed.')
-    parser.add_argument('--schema_version', default=3,
+    parser.add_argument('--schema_version', default=3, type=int,
                         help="""
 The schema version of the DM tables.
 v1: '_flux', '_fluxSigma'


### PR DESCRIPTION
* Produce the trim versions of the Run 2.1i DR1 ('dr1b') Object Table files from the IN2P3 Science PIpelines processing, which already generates `object_tract_????.hdf5` files.
* There were some bug fixes along the way in preparing this
* There was one somewhat confounding UnicodeDecodingError for one patch.  This patch was just skipped.
* Add documentation to README.