### PR TITLE
capture minor change when using more recent versions of DMstack

### DIFF
--- a/scripts/merge_tract_cat.py
+++ b/scripts/merge_tract_cat.py
@@ -194,7 +194,7 @@ def load_patch(butler_or_repo, tract, patch,
         # Then join in memory space.
         cat = cat.asAstropy().to_pandas()
 
-        calib = butler.get('deepCoadd_calexp_calib', this_data)
+        calib = butler.get('deepCoadd_calexp_photoCalib', this_data)
         calib.setThrowOnNegativeFlux(False)
 
         mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']].values, cat[flux_names['psf_flux_err']].values)


### PR DESCRIPTION
This minor change represents the actual code used to generate the HDF5 DPDD files for Run2.1i and Run2.1.1i.