### PR TITLE
Ensure columns in merged_cat are in same order to take advantage of native merge

### DIFF
--- a/scripts/make_object_catalog.py
+++ b/scripts/make_object_catalog.py
@@ -7,7 +7,6 @@ import os
 import re
 
 import numpy as np
-from astropy.table import hstack
 
 from lsst.daf.persistence import Butler
 from lsst.daf.persistence.butlerExceptions import NoResults
@@ -20,6 +19,7 @@ def _ensure_butler_instance(butler_or_repo):
 
 
 _default_fill_value = {'i': -1, 'b': False, 'U': ''}
+
 
 def _get_fill_value(name, dtype):
     kind = np.dtype(dtype).kind
@@ -139,10 +139,7 @@ def merge_coadd_forced_src(butler, tract, patch, filters='ugrizy',
     ref_table['tract'] = int(tract)
     ref_table['patch'] = str(patch)
 
-    cat_dtype = None
-    missing_filters = list()
-    tables_to_merge = [ref_table]
-
+    tables_to_merge = dict()
     for filter_this in filters:
         filter_name = filters.get(filter_this) if hasattr(filters, 'get') else filter_this
         this_data_id = dict(tract_patch_data_id, filter=filter_name)
@@ -152,7 +149,6 @@ def merge_coadd_forced_src(butler, tract, patch, filters='ugrizy',
         except NoResults as e:
             if verbose:
                 print("  ", e)
-            missing_filters.append(filter_this)
             continue
 
         cat = cat.asAstropy()
@@ -166,24 +162,28 @@ def merge_coadd_forced_src(butler, tract, patch, filters='ugrizy',
         calib = butler.get('deepCoadd_calexp_photoCalib', this_data_id)
         cat['FLUXMAG0'] = calib.getInstFluxAtZeroMagnitude()
 
-        if cat_dtype is None:
-            cat_dtype = cat.dtype
+        tables_to_merge[filter_this] = cat
 
-        cat.meta = None
-        for name in cat_dtype.names:
-            cat.rename_column(name, '{}_{}'.format(filter_this, name))
-
-        tables_to_merge.append(cat)
+    try:
+        cat_dtype = next(iter(tables_to_merge.values())).dtype
+    except StopIteration:
+        if verbose:
+            print("  No filter can be found in deepCoadd_forced_src")
+        return
 
     if debug:
-        assert cat_dtype is not None
+        assert all(cat_dtype == cat.dtype for cat in tables_to_merge.values())
 
-    merged_cat = hstack(tables_to_merge, join_type='exact')
-    del tables_to_merge
-
-    for filter_this in missing_filters:
-        for name, (dt, _) in cat_dtype.fields.items():
-            merged_cat['{}_{}'.format(filter_this, name)] = _get_fill_value(name, dt)
+    merged_cat = ref_table  # merged_cat will start with the reference table
+    for filter_this in filters:
+        if filter_this in tables_to_merge:
+            cat = tables_to_merge[filter_this]
+            for name in cat_dtype.names:
+                merged_cat['{}_{}'.format(filter_this, name)] = cat[name]
+            del cat, tables_to_merge[filter_this]
+        else:
+            for name, (dt, _) in cat_dtype.fields.items():
+                merged_cat['{}_{}'.format(filter_this, name)] = _get_fill_value(name, dt)
 
     return merged_cat.to_pandas() if return_pandas else merged_cat
 

--- a/scripts/make_object_catalog.py
+++ b/scripts/make_object_catalog.py
@@ -26,7 +26,7 @@ def _get_fill_value(name, dtype):
     fill_value = _default_fill_value.get(kind, np.nan)
     if kind == 'b' and (name.endswith('_flag_bad') or name.endswith('_flag_noGoodPixels')):
         fill_value = True
-    return fill_value
+    return np.array(fill_value, dtype=np.dtype(dtype))
 
 
 def generate_object_catalog(output_dir, butler, tract, patches=None,
@@ -175,6 +175,7 @@ def merge_coadd_forced_src(butler, tract, patch, filters='ugrizy',
         assert all(cat_dtype == cat.dtype for cat in tables_to_merge.values())
 
     merged_cat = ref_table  # merged_cat will start with the reference table
+    merged_cat.meta = None
     for filter_this in filters:
         if filter_this in tables_to_merge:
             cat = tables_to_merge[filter_this]


### PR DESCRIPTION
Currently `make_object_catalog.py` would generate one parquet file for each patch to allow easy embarrassingly parallelization. After all the patches are process, one has to run `merge_parquet_files.py` to merge all patches in the same tract into one single parquet file. 

In `merge_parquet_files.py`, the merge is done by loading all parquet files into memory as pandas DataFrame, and then use `pd.concat` to join them. This is necessary because the columns in different patches are not necessarily in the same order. 

So why different patches do not have the columns in the same order? This is because different patches have different sets of available filters, and the current implementation appends the missing filters at the end of the columns. 

To address these issues, this PR makes two changes:
1. Ensure the column orders in different patches are always the same. This change is implemented in `make_object_catalog.py`
2. Use pyarrow native method for appending parquet files when we know the schema is consistent. This change is implemented in `merge_parquet_files.py`. 

Note that for the second change, I've only implemented the pyarrow case. There may be an equivalent method for fastparquet but I haven't looked into it. 

I have also not tested these two updated scripts because I don't have the machinery set up yet -- @johannct I'd very much appreciate if you can help with testing them! 