### PR TITLE
fix the call to calibration dataset _photoCalib instead of _calib, an…

### DIFF
--- a/scripts/merge_forced_source_cat.py
+++ b/scripts/merge_forced_source_cat.py
@@ -121,8 +121,19 @@ def load_detector(data_ref, object_table=None, matching_radius=1,
 
     # Calibrate magnitudes and fluxes
     calib = data_ref.get('calexp_photoCalib')
-    # For now we just extract the grey FLUXMAG0
-    cat['FLUXMAG0'] = calib.getInstFluxAtZeroMagnitude()
+
+    mag, mag_err = calib.instFluxToMagnitude(cat[flux_names['psf_flux']].values,
+                                      cat[flux_names['psf_flux_err']].values)
+
+    cat['mag'] = mag
+    cat['mag_err'] = mag_err
+    cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
+                        cat[flux_names['psf_flux_err']])
+
+    # TODO Need to calibrate fluxes as well
+    # For now we'll just save this information in an additional column
+    # to be available further downstream.
+    cat['fluxmag0'] = calib.getInstFluxAtZeroMagnitude()
 
     # Restrict to columns that we need
     cat = cat[columns_to_keep]

--- a/scripts/merge_forced_source_cat.py
+++ b/scripts/merge_forced_source_cat.py
@@ -120,22 +120,9 @@ def load_detector(data_ref, object_table=None, matching_radius=1,
     cat['filter'] = data_ref.dataId['filter']
 
     # Calibrate magnitudes and fluxes
-    calib = data_ref.get('calexp_calib')
-    calib.setThrowOnNegativeFlux(False)
-
-    mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']].values,
-                                      cat[flux_names['psf_flux_err']].values)
-
-    cat['mag'] = mag
-    cat['mag_err'] = mag_err
-    cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
-                        cat[flux_names['psf_flux_err']])
-
-    # TODO Need to calibrate fluxes as well
-    # For now we'll just save this information in an additional column
-    # to be available further downstream.
-    flux_mag0, flux_mag0_err = calib.getFluxMag0()
-    cat['fluxmag0'] = flux_mag0
+    calib = data_ref.get('calexp_photoCalib')
+    # For now we just extract the grey FLUXMAG0
+    cat['FLUXMAG0'] = calib.getInstFluxAtZeroMagnitude()
 
     # Restrict to columns that we need
     cat = cat[columns_to_keep]

--- a/scripts/merge_source_cat.py
+++ b/scripts/merge_source_cat.py
@@ -186,28 +186,20 @@ def load_detector(data_ref,
 
     # Calibrate magnitudes and fluxes
     calib_dataset_map = {'src': 'calexp', 'deepDiff_diaSrc': 'deepDiff_differenceExp'}
-    try:
-        calib = data_ref.get(datasetType=calib_dataset_map[dataset]+'_photoCalib')
-        cat['FLUXMAG0'] = calib.getInstFluxAtZeroMagnitude()
-    except AttributeError:
-        calib = data_ref.get(datasetType=calib_dataset_map[dataset]+'_calib')
+    calib = data_ref.get(datasetType=calib_dataset_map[dataset]+'_photoCalib')
 
-        calib.setThrowOnNegativeFlux(False)
-
-        mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']].values,
+    mag, mag_err = calib.instFluxToMagnitude(cat[flux_names['psf_flux']].values,
                                       cat[flux_names['psf_flux_err']].values)
 
-        cat['mag'] = mag
-        cat['mag_err'] = mag_err
+    cat['mag'] = mag
+    cat['mag_err'] = mag_err
+    cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
+                        cat[flux_names['psf_flux_err']])
 
-        # TODO Need to calibrate fluxes as well
-        # For now we'll just save this information in an additional column
-        # to be available further downstream.
-        flux_mag0, flux_mag0_err = calib.getFluxMag0()
-        cat['fluxmag0'] = flux_mag0
-        
-        cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
-                            cat[flux_names['psf_flux_err']])
+    # TODO Need to calibrate fluxes as well
+    # For now we'll just save this information in an additional column
+    # to be available further downstream.
+    cat['fluxmag0'] = calib.getInstFluxAtZeroMagnitude()
 
     if (object_table is not None or object_dataset is not None) and (len(cat) > 0):
         # Associate with closest

--- a/scripts/merge_source_cat.py
+++ b/scripts/merge_source_cat.py
@@ -188,24 +188,26 @@ def load_detector(data_ref,
     calib_dataset_map = {'src': 'calexp', 'deepDiff_diaSrc': 'deepDiff_differenceExp'}
     try:
         calib = data_ref.get(datasetType=calib_dataset_map[dataset]+'_photoCalib')
+        cat['FLUXMAG0'] = calib.getInstFluxAtZeroMagnitude()
     except AttributeError:
         calib = data_ref.get(datasetType=calib_dataset_map[dataset]+'_calib')
 
-    calib.setThrowOnNegativeFlux(False)
+        calib.setThrowOnNegativeFlux(False)
 
-    mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']].values,
+        mag, mag_err = calib.getMagnitude(cat[flux_names['psf_flux']].values,
                                       cat[flux_names['psf_flux_err']].values)
 
-    cat['mag'] = mag
-    cat['mag_err'] = mag_err
-    cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
-                        cat[flux_names['psf_flux_err']])
+        cat['mag'] = mag
+        cat['mag_err'] = mag_err
 
-    # TODO Need to calibrate fluxes as well
-    # For now we'll just save this information in an additional column
-    # to be available further downstream.
-    flux_mag0, flux_mag0_err = calib.getFluxMag0()
-    cat['fluxmag0'] = flux_mag0
+        # TODO Need to calibrate fluxes as well
+        # For now we'll just save this information in an additional column
+        # to be available further downstream.
+        flux_mag0, flux_mag0_err = calib.getFluxMag0()
+        cat['fluxmag0'] = flux_mag0
+        
+        cat['SNR'] = np.abs(cat[flux_names['psf_flux']] /
+                            cat[flux_names['psf_flux_err']])
 
     if (object_table is not None or object_dataset is not None) and (len(cat) > 0):
         # Associate with closest

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -96,8 +96,8 @@ def write_dataframe_to_files(
     # Append iff the file already exists
     parquet_append = append and os.path.exists(output_filename)
     df.to_parquet(output_filename,
-                  append=parquet_append,
-                  file_scheme=parquet_scheme,
+                  #append=parquet_append,
+                  #file_scheme=parquet_scheme,
                   engine=parquet_engine,
                   compression=parquet_compression)
 


### PR DESCRIPTION
…d remove the computation of mag, magerrs and SNR in case of _photoCalib; comment out two offending lines in write_gcr_to_parquet.py that are incompatible with pyarrow 0.13