### PR TITLE
Keep object ID and store tract/patch info for metacal parquet files

### DIFF
--- a/scripts/make_metacal_catalog.py
+++ b/scripts/make_metacal_catalog.py
@@ -142,8 +142,11 @@ def load_metacal_patch(butler, tract, patch, verbose=False, return_pandas=True,
     del metacal["coord_ra"]
     del metacal["coord_dec"]
     del metacal["parent"]
-    del metacal["id"]
 
+    # Store tract and patch info
+    metacal['tract'] = int(tract)
+    metacal['patch'] = str(patch)
+    
     return metacal.to_pandas() if return_pandas else metacal
 
 


### PR DESCRIPTION
As title. While it takes a bit of space, this will save us much trouble debugging. 