### PR TITLE
Rewrite write_gcr_to_parquet.py

### DIFF
--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -52,10 +52,6 @@ def convert_cat_to_parquet(reader,
         Any other keyword arguments will be passed to `config_overwrite` when loading the catalog
     """
 
-    # FIXME: A temporary fix. Should be removed when https://github.com/LSSTDESC/gcr-catalogs/pull/437 is merged
-    if 'tract' in kwargs and kwargs['tract'] is None:
-        del kwargs['tract']
-
     if output_filename is None:
         output_filename = str(reader)
         if kwargs.get('tract'):

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -51,6 +51,11 @@ def convert_cat_to_parquet(reader,
     **kwargs
         Any other keyword arguments will be passed to `config_overwrite` when loading the catalog
     """
+
+    # FIXME: A temporary fix. Should be removed when https://github.com/LSSTDESC/gcr-catalogs/pull/437 is merged
+    if 'tract' in kwargs and kwargs['tract'] is None:
+        del kwargs['tract']
+
     if output_filename is None:
         output_filename = str(reader)
         if kwargs.get('tract'):


### PR DESCRIPTION
This PR rewrites the script `write_gcr_to_parquet.py` that takes a catalog in GCRCatalogs and writes it to a parquet file. 

The original script is not memory-efficient and does not utilize some native feature pyarrow (since at that time we were supporting both pyarrow and fastparquet). Now that we are settled with pyarrow, much of this script should be rewritten to make use of them. 

The PR also now allows users to specify  `config_overwrite` to be passed to GCRCatalogs. In particular, this enables users to load only one tract at a time. 

@johannct can you test this? I was able to use this new script to generate one tract of `dc2_object_run2.2i_dr3` using NERSC's jupyter notebook in just a few seconds. On your machine it might even works with all tracts at once. The call signature is

```bash
   python write_gcr_to_parquet.py dc2_object_run2.2i_dr3 [--tract tract]
```