### PR TITLE
Improve write_gcr_to_parquet.py

### DIFF
--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -65,7 +65,7 @@ def convert_cat_to_parquet(reader,
         columns = cat.list_all_quantities(include_native=include_native)
         if not include_native:
             for col in ("tract", "patch"):
-                if cat.has_quantity(col):
+                if col not in columns and cat.has_quantity(col):
                     columns.append(col)
 
     def chunk_data_generator():

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -67,8 +67,10 @@ def convert_cat_to_parquet(reader,
         for data in cat.get_quantities(columns, return_iterator=True):
             table = pa_table_from_pydict(data)
             del data
-            if hasattr(cat, "close_all_file_handles"):
+            try:
                 cat.close_all_file_handles()
+            except (AttributeError, TypeError):
+                pass
             yield table
 
     chunk_iter = chunk_data_generator()

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -52,7 +52,7 @@ def convert_cat_to_parquet(reader,
         Include the native quantities from the GCR reader class
         in addition to the standardized derived quantities.
     partition : bool, optional (default: False)
-        If true, save each partition as a single file
+        If true, save each chunk as a separate file
     **kwargs
         Any other keyword arguments will be passed to `config_overwrite` when loading the catalog
     """
@@ -141,7 +141,7 @@ This would only process one tract and produce the file 'dc2_object_run2.2i_dr3_t
     parser.add_argument('--output_filename', help='Output filename. Default to <reader>.parquet')
     parser.add_argument('--include_native', action='store_true',
                         help='Include the native quantities along with the derived GCR quantities')
-    parser.add_argument('--partition', action='store_true', help='Store each partition as a single file')
+    parser.add_argument('--partition', action='store_true', help='Store each chunk as a separate file')
     parser.add_argument('--tract', type=int, help='tract to process')
 
     convert_cat_to_parquet(**vars(parser.parse_args()))

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -61,7 +61,12 @@ def convert_cat_to_parquet(reader,
     config_overwrite = dict(use_cache=False, **kwargs)
     cat = GCRCatalogs.load_catalog(reader, config_overwrite=config_overwrite)
 
-    columns = columns or cat.list_all_quantities(include_native=include_native)
+    if not columns:
+        columns = cat.list_all_quantities(include_native=include_native)
+        if not include_native:
+            for col in ("tract", "patch"):
+                if cat.has_quantity(col):
+                    columns.append(col)
 
     def chunk_data_generator():
         for data in cat.get_quantities(columns, return_iterator=True):

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -95,7 +95,7 @@ def convert_cat_to_parquet(reader,
     if partition:
         for i, table in enumerate(chunk_iter):
             if is_tract_catalog:
-                output_filename_this = output_filename.format('_tract{}'.format(table['tract'][0]))
+                output_filename_this = output_filename.format('_tract{}'.format(table.column('tract')[0]))
             else:
                 output_filename_this = output_filename.format('_chunk{}'.format(i))
             with pq.ParquetWriter(output_filename_this, table.schema, flavor='spark') as pqwriter:


### PR DESCRIPTION
(Updated 6/25/2020): This PR adds several improvements to `write_gcr_to_parquet.py`. 
- Reduce the memory footprint of `write_gcr_to_parquet.py` by calling `close_all_file_handles` (if available in the reader) and delete unused references
- Always include `tract` and `patch` if available for "tract catalogs"
- Add a `partition` option to save each partition as a single file. 
