### PR TITLE
add healpix option in write_gcr_to_parquet.py (for converting cosmoDC2 to parquet)

### DIFF
--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -104,6 +104,8 @@ def convert_cat_to_parquet(reader,
     else:
         if is_tract_catalog and kwargs.get('tract'):
             output_filename_this = output_filename.format('_tract{}'.format(kwargs['tract']))
+        elif kwargs.get('healpix_pixels'):
+            output_filename_this = output_filename.format('_healpix{}'.format(kwargs['healpix_pixels'][0]))
         else:
             output_filename_this = output_filename.format('')
 
@@ -143,6 +145,7 @@ This would only process one tract and produce the file 'dc2_object_run2.2i_dr3_t
                         help='Include the native quantities along with the derived GCR quantities')
     parser.add_argument('--partition', action='store_true', help='Store each chunk as a separate file')
     parser.add_argument('--tract', type=int, help='tract to process')
+    parser.add_argument('--healpix', type=int, nargs='1', dest='healpix_pixels', help='healpix to process (for cosmoDC2)')
 
     convert_cat_to_parquet(**vars(parser.parse_args()))
 

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -74,18 +74,18 @@ def convert_cat_to_parquet(reader,
                     columns.append(col)
 
     # Check all column names are unique after sanitized
-    columns_sanitized = dict()
+    columns = sorted(columns)
+    columns_sanitized = {str(col).lower(): col for col in columns}
+    new_columns = list(columns_sanitized.values())
     for col in columns:
-        col_sanitized = str(col).lower()
-        if col_sanitized in columns_sanitized:
+        if col not in new_columns:
             warnings.warn(
                 "Column name `{0}` collides with `{1}` after sterilized; `{0}` will not be included.".format(
-                    col, columns_sanitized[col_sanitized]
+                    col, columns_sanitized[str(col).lower()]
                 )
             )
-        else:
-            columns_sanitized[col_sanitized] = col
-    columns = list(columns_sanitized.values())
+    columns = new_columns
+    del columns_sanitized, new_columns
 
     def chunk_data_generator():
         for data in cat.get_quantities(columns, return_iterator=True):

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -80,7 +80,7 @@ def convert_cat_to_parquet(reader,
     for col in columns:
         if col not in new_columns:
             warnings.warn(
-                "Column name `{0}` collides with `{1}` after sterilized; `{0}` will not be included.".format(
+                "Column name `{0}` collides with `{1}` after sanitized; `{0}` will not be included.".format(
                     col, columns_sanitized[str(col).lower()]
                 )
             )

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -145,7 +145,7 @@ This would only process one tract and produce the file 'dc2_object_run2.2i_dr3_t
                         help='Include the native quantities along with the derived GCR quantities')
     parser.add_argument('--partition', action='store_true', help='Store each chunk as a separate file')
     parser.add_argument('--tract', type=int, help='tract to process')
-    parser.add_argument('--healpix', type=int, nargs='1', dest='healpix_pixels', help='healpix to process (for cosmoDC2)')
+    parser.add_argument('--healpix', type=int, nargs=1, dest='healpix_pixels', help='healpix to process (for cosmoDC2)')
 
     convert_cat_to_parquet(**vars(parser.parse_args()))
 


### PR DESCRIPTION
This PR adds an `--healpix` option in `scripts/write_gcr_to_parquet.py` so that it is more convenient to use this script to convert cosmoDC2 to parquet. The option can be used as:

```base
python ~/desc/DC2-production/scripts/write_gcr_to_parquet.py cosmoDC2_v1.1.4_image --healpix=8786
```

As a test, I am generating a few healpix pixels in `/global/cscratch1/sd/yymao/desc/cosmodc2-parquet` on NERSC if anyone wants to take a look. (cc @JoanneBogart @plaszczy @cwwalter)