### PR TITLE
Enable processing multiple files at once

### DIFF
--- a/scripts/merge_truth_per_tract.py
+++ b/scripts/merge_truth_per_tract.py
@@ -39,7 +39,7 @@ def merge_truth_per_tract(input_dir, truth_types=("truth_", "star_", "sn_"), val
     silent : bool, optional (default: False)
         If true, turn off most printout.
     """
-    my_print = (lambda x: None) if silent else print
+    my_print = (lambda *x: None) if silent else print
 
     my_print("Merging all files in", input_dir)
     files_to_merge = sorted(os.listdir(input_dir))
@@ -99,7 +99,7 @@ def match_object_with_merged_truth(truth_cat, object_cat, validate=False, silent
     silent : bool, optional (default: False)
         If true, turn off most printout.
     """
-    my_print = (lambda x: None) if silent else print
+    my_print = (lambda *x: None) if silent else print
 
     if isinstance(truth_cat, str):
         my_print("Loading truth catalog from", truth_cat)
@@ -159,7 +159,7 @@ def match_object_with_merged_truth(truth_cat, object_cat, validate=False, silent
 
 
 def save_df_to_disk(df, output_dir, name="truth", silent=False, **kwargs):
-    my_print = (lambda x: None) if silent else print
+    my_print = (lambda *x: None) if silent else print
 
     tract = df.loc[0, "tract"]
     output_path = os.path.join(output_dir, "{}_tract{}.parquet".format(name, tract))

--- a/scripts/merge_truth_per_tract.py
+++ b/scripts/merge_truth_per_tract.py
@@ -226,7 +226,7 @@ Because this is an I/O intensive work, it is *not* recommended that you use too 
     parser.add_argument("--matching-only", action="store_true")
     parser.add_argument("--tracts", nargs="+", type=int, help="List of tract numbers to run. Use to format input_dir and object_catalog_path")
     parser.add_argument("--tract-list", help="File contains a list of tract numbers to run. Use to format input_dir and object_catalog_path")
-    parser.add_argument("--n-cores", type=int, default=1)
+    parser.add_argument("--n-cores", "--cores", dest="n_cores", type=int, default=1)
 
     args = parser.parse_args()
     kwargs = vars(args)

--- a/scripts/merge_truth_per_tract.py
+++ b/scripts/merge_truth_per_tract.py
@@ -54,12 +54,21 @@ def merge_truth_per_tract(input_dir, truth_types=("truth_", "star_", "sn_"), val
             if filename.startswith(type_prefix):
                 type_code = i + 1
 
+        if not type_code:
+            msg = "Cannot identify truth type for {}".format(filename)
+            if validate:
+                raise ValueError(msg)
+            warnings.warn(msg)
+
         # obtain healpix id for galaxies (type_code == 1)
         healpix = -1
         if type_code == 1:
             m = re.search(r"_hp(\d+)\b", filename)
             if m is None:
-                warnings.warn("Cannot identify healpix id in", filename)
+                msg = "Cannot identify healpix id for {}".format(filename)
+                if validate:
+                    raise ValueError(msg)
+                warnings.warn(msg)
             else:
                 healpix = int(m.groups()[0])
 

--- a/scripts/merge_truth_per_tract.py
+++ b/scripts/merge_truth_per_tract.py
@@ -20,7 +20,7 @@ __all__ = ["merge_truth_per_tract", "match_object_with_merged_truth"]
 def merge_truth_per_tract(input_dir, truth_types=("truth_", "star_", "sn_"), validate=False, silent=False, **kwargs):
     """Merge all the truth catalogs in one single tract directory.
 
-    This function assumes the truth catalogs are in parquet format and have specifc file name patterns.
+    This function assumes the truth catalogs are in parquet format and have specific file name patterns.
     The filename prefix should match one of those specified in truth_types.
     For galaxy type (filename starting with "truth_"),
     it is further assumed that the cosmodc2 healpix id is embedded in the filename.
@@ -35,7 +35,7 @@ def merge_truth_per_tract(input_dir, truth_types=("truth_", "star_", "sn_"), val
     truth_types : tuple of str, optional (default: ("truth_", "star_", "sn_"))
         The types of truth objects. The string should be the prefix of truth files.
     validate : bool, optional (default: False)
-        If true, check the tract column has only one value
+        If true, check that the tract column has only one value
     silent : bool, optional (default: False)
         If true, turn off most printout.
     """
@@ -95,7 +95,7 @@ def match_object_with_merged_truth(truth_cat, object_cat, validate=False, silent
     Optional Parameters
     ----------------
     validate : bool, optional (default: False)
-        If true, check the matching is perform properly.
+        If true, check that the matching is performed properly.
     silent : bool, optional (default: False)
         If true, turn off most printout.
     """

--- a/scripts/repartition_into_tracts.py
+++ b/scripts/repartition_into_tracts.py
@@ -137,7 +137,7 @@ Files within each tract directory can be then merged to produce a single file (u
     parser.add_argument("-o", '--output-root-dir', default='.', help="Output root directory.")
     parser.add_argument("--skymap-source-repo", default="2.2i_dr6_wfd")
     parser.add_argument("--silent", action="store_true")
-    parser.add_argument("--n-cores", type=int)
+    parser.add_argument("--n-cores", "--cores", dest="n_cores", type=int)
 
     repartition_into_tracts(**vars(parser.parse_args()))
 

--- a/scripts/repartition_into_tracts.py
+++ b/scripts/repartition_into_tracts.py
@@ -115,6 +115,8 @@ def repartition_into_tracts(
             output_path = os.path.join(output_dir, os.path.basename(input_file))
             df_this_tract.to_parquet(output_path, index=False)
 
+        my_print("Done with", input_file)
+
 
 def main():
     usage = """Take a parquet catalog and split it into tracts according to a given skymap, and write to disk

--- a/scripts/repartition_into_tracts.py
+++ b/scripts/repartition_into_tracts.py
@@ -83,7 +83,7 @@ def repartition_into_tracts(
     silent : bool, optional (default: False)
         If true, turn off most printout.
     """
-    my_print = (lambda x: None) if silent else print
+    my_print = (lambda *x: None) if silent else print
     tqdm_disable = silent or None
 
     repo = desc_dc2_dm_data.REPOS.get(skymap_source_repo, skymap_source_repo)

--- a/scripts/repartition_into_tracts.py
+++ b/scripts/repartition_into_tracts.py
@@ -106,7 +106,7 @@ def repartition_into_tracts(
             tractpatch = pool.starmap(get_tract_patch_arrays, zip(skymap_arr, ra_arr, dec_arr, tqdm_arr))
         df["tract"] = np.concatenate([tp[0] for tp in tractpatch])
         df["patch"] = np.concatenate([tp[1] for tp in tractpatch])
-        del skymap_arr, skymap, ra_arr, dec_arr, tqdm_arr, tractpatch
+        del skymap_arr, ra_arr, dec_arr, tqdm_arr, tractpatch
 
         my_print("Writing out parquet file for each tract in", output_root_dir)
         for tract, df_this_tract in tqdm(df.groupby("tract"), total=df["tract"].nunique(False), disable=tqdm_disable):

--- a/scripts/repartition_into_tracts.py
+++ b/scripts/repartition_into_tracts.py
@@ -53,7 +53,7 @@ def get_tract_patch_arrays(skymap, ra_arr, dec_arr, disable_tqdm=None):
 
 
 def repartition_into_tracts(
-    input_file,
+    input_files,
     output_root_dir,
     skymap_source_repo,
     ra_label="ra",
@@ -66,8 +66,8 @@ def repartition_into_tracts(
 
     Parameters
     ----------
-    input_file : str
-        Path to the input parquet file.
+    input_files : list of str
+        List of paths to the input parquet file.
     output_root_dir : str
         Path to the output directory. The output files will have the following filename
         <output_root_dir>/<tract>/<input_file_basename>
@@ -90,29 +90,30 @@ def repartition_into_tracts(
     my_print("Obtain skymap from", repo)
     skymap = Butler(repo).get("deepCoadd_skyMap")
 
-    my_print("Loading input parquet file", input_file)
-    df = pd.read_parquet(input_file)
+    for input_file in input_files:
+        my_print("Loading input parquet file", input_file)
+        df = pd.read_parquet(input_file)
 
-    # Add tract, patch columns to df (i.e., input)
-    n_cores = get_number_of_workers(n_cores)
-    my_print("Finding tract and patch for each row, using", n_cores, "cores")
-    skymap_arr = [skymap] * n_cores
-    ra_arr = np.array_split(df[ra_label].values, n_cores)
-    dec_arr = np.array_split(df[dec_label].values, n_cores)
-    tqdm_arr = [True] * n_cores
-    tqdm_arr[0] = tqdm_disable
-    with mp.Pool(n_cores) as pool:
-        tractpatch = pool.starmap(get_tract_patch_arrays, zip(skymap_arr, ra_arr, dec_arr, tqdm_arr))
-    df["tract"] = np.concatenate([tp[0] for tp in tractpatch])
-    df["patch"] = np.concatenate([tp[1] for tp in tractpatch])
-    del skymap_arr, skymap, ra_arr, dec_arr, tqdm_arr, tractpatch
+        # Add tract, patch columns to df (i.e., input)
+        n_cores = get_number_of_workers(n_cores)
+        my_print("Finding tract and patch for each row, using", n_cores, "cores")
+        skymap_arr = [skymap] * n_cores
+        ra_arr = np.array_split(df[ra_label].values, n_cores)
+        dec_arr = np.array_split(df[dec_label].values, n_cores)
+        tqdm_arr = [True] * n_cores
+        tqdm_arr[0] = tqdm_disable
+        with mp.Pool(n_cores) as pool:
+            tractpatch = pool.starmap(get_tract_patch_arrays, zip(skymap_arr, ra_arr, dec_arr, tqdm_arr))
+        df["tract"] = np.concatenate([tp[0] for tp in tractpatch])
+        df["patch"] = np.concatenate([tp[1] for tp in tractpatch])
+        del skymap_arr, skymap, ra_arr, dec_arr, tqdm_arr, tractpatch
 
-    my_print("Writing out parquet file for each tract in", output_root_dir)
-    for tract, df_this_tract in tqdm(df.groupby("tract"), total=df["tract"].nunique(False), disable=tqdm_disable):
-        output_dir = os.path.join(output_root_dir, str(tract))
-        os.makedirs(output_dir, exist_ok=True)
-        output_path = os.path.join(output_dir, os.path.basename(input_file))
-        df_this_tract.to_parquet(output_path, index=False)
+        my_print("Writing out parquet file for each tract in", output_root_dir)
+        for tract, df_this_tract in tqdm(df.groupby("tract"), total=df["tract"].nunique(False), disable=tqdm_disable):
+            output_dir = os.path.join(output_root_dir, str(tract))
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, os.path.basename(input_file))
+            df_this_tract.to_parquet(output_path, index=False)
 
 
 def main():
@@ -130,7 +131,7 @@ Files within each tract directory can be then merged to produce a single file (u
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
-    parser.add_argument("input_file", help="Parquet file to read.")
+    parser.add_argument("input_files", nargs="+", help="Parquet file(s) to read.")
     parser.add_argument("-o", '--output-root-dir', default='.', help="Output root directory.")
     parser.add_argument("--skymap-source-repo", default="2.2i_dr6_wfd")
     parser.add_argument("--silent", action="store_true")

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -121,6 +121,12 @@ def convert_cat_to_parquet(reader,
     """
     my_print = (lambda *x: None) if silent else print
 
+    # make sure check point dir is writable
+    if check_point_dir is not None:
+        os.makedirs(check_point_dir, exist_ok=True)
+        if not os.access(check_point_dir, os.W_OK):
+            raise ValueError(check_point_dir, "not writable!")
+
     if isinstance(reader, BaseGenericCatalog):
         cat = reader
     else:

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -195,13 +195,11 @@ one can specify a subset of tracts to process. Use --partition to put each tract
 This would process only two tracts and produce two files:
 'dc2_object_run2.2i_dr3_tract3830.parquet' and 'dc2_object_run2.2i_dr3_tract3831.parquet'
 
-If you want to process all tracts, but create one output file per tract, use just --partition.
-You can optionally specify --n-cores to speed things up.
-Because this is an I/O intensive work, it is *not* recommended that you use too many cores at once.
+If you want to process *all* tracts, but create one output file per tract, use just --partition with out --tracts:
 
-   python %(prog)s dc2_object_run2.2i_dr3 --partition --n-cores=4
+   python %(prog)s dc2_object_run2.2i_dr3 --partition
 
-If you are working with cosmoDC2, replace "tract" with "healpix" and the above instructions still apply.
+If you are working with cosmoDC2, replace "--tracts" with "--healpix-pixels" and the above instructions still apply.
 
 """
     parser = ArgumentParser(description=usage,

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -4,6 +4,7 @@
 Write a catalog in GCRCatalogs out to a Parquet file
 """
 import warnings
+import time
 from argparse import ArgumentParser, RawTextHelpFormatter
 
 import pyarrow as pa
@@ -43,14 +44,14 @@ def _chunk_data_generator(cat, columns, native_filters=None):
 def _write_one_partition(output_path, cat, columns, native_filters=None, silent=False):
     my_print = (lambda *x: None) if silent else print
 
-    my_print("Generating", output_path)
+    my_print("Generating", output_path, time.strftime("[%H:%M:%S]"))
     chunk_iter = _chunk_data_generator(cat, columns, native_filters)
     table = next(chunk_iter)
     with pq.ParquetWriter(output_path, table.schema, flavor='spark') as pqwriter:
         pqwriter.write_table(table)
         for table in chunk_iter:
             pqwriter.write_table(table)
-    my_print("Done with", output_path)
+    my_print("Done with", output_path, time.strftime("[%H:%M:%S]"))
 
 
 def convert_cat_to_parquet(reader,
@@ -154,10 +155,10 @@ def convert_cat_to_parquet(reader,
     elif partition == "iter":
         for i, table in enumerate(_chunk_data_generator(cat, columns)):
             output_path = output_filename.format(i)
-            my_print("Generating", output_path)
+            my_print("Generating", output_path, time.strftime("[%H:%M:%S]"))
             with pq.ParquetWriter(output_filename.format(i), table.schema, flavor='spark') as pqwriter:
                 pqwriter.write_table(table)
-            my_print("Done with", output_path)
+            my_print("Done with", output_path, time.strftime("[%H:%M:%S]"))
 
     elif partition_values:
         for value in partition_values:

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -244,6 +244,12 @@ If you want to process *all* tracts, but create one output file per tract, use j
 
 If you are working with cosmoDC2, replace "--tracts" with "--healpix-pixels" and the above instructions still apply.
 
+When running this script with cosmoDC2, it's useful to enable --checkpoint-dir. This will keep track of the generation
+status in the checkpoint dir by creating empty files <filename>.lock and <filename>.done.
+The former means the corresponding file is being generated, and the latter means the corresponding file is completed.
+
+   python %(prog)s cosmoDC2_v1.1.4_image --partition --checkpoint-dir=/path/to/checkpoint/dir
+
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)

--- a/scripts/write_gcr_to_parquet.py
+++ b/scripts/write_gcr_to_parquet.py
@@ -4,6 +4,7 @@
 Write a catalog in GCRCatalogs out to a Parquet file
 """
 import warnings
+import multiprocessing as mp
 from argparse import ArgumentParser, RawTextHelpFormatter
 
 import pyarrow as pa
@@ -29,11 +30,37 @@ else:
         return pa.Table.from_arrays(arrays, names)
 
 
+def _chunk_data_generator(cat, columns, native_filters=None, **kwargs):
+    for data in cat.get_quantities(columns, native_filters=native_filters, return_iterator=True):
+        table = pa_table_from_pydict(data)
+        del data
+        try:
+            cat.close_all_file_handles()
+        except (AttributeError, TypeError):
+            pass
+        yield table
+
+
+def _write_one_partition(kwargs):
+    my_print = (lambda *x: None) if kwargs.get("silent") else print
+    output_path = kwargs["output_path"]
+    my_print("Generating", output_path)
+    chunk_iter = _chunk_data_generator(**kwargs)
+    table = next(chunk_iter)
+    with pq.ParquetWriter(output_path, table.schema, flavor='spark') as pqwriter:
+        pqwriter.write_table(table)
+        for table in chunk_iter:
+            pqwriter.write_table(table)
+    my_print("Done with", output_path)
+
+
 def convert_cat_to_parquet(reader,
                            output_filename=None,
                            columns=None,
                            include_native=False,
                            partition=False,
+                           n_cores=1,
+                           silent=False,
                            **kwargs):
     """Write a catalog in GCRCatalogs out to a Parquet file
 
@@ -57,18 +84,23 @@ def convert_cat_to_parquet(reader,
     **kwargs
         Any other keyword arguments will be passed to `config_overwrite` when loading the catalog
     """
+    my_print = (lambda *x: None) if silent else print
 
     if isinstance(reader, BaseGenericCatalog):
         cat = reader
     else:
+        my_print("Loading", reader, "from GCRCatalogs")
         config_overwrite = dict(use_cache=False, **kwargs)
         cat = GCRCatalogs.load_catalog(reader, config_overwrite=config_overwrite)
 
-    is_tract_catalog = isinstance(cat, DC2DMTractCatalog)
+    my_print("Checking if all column names exist and are unique")
 
-    if not columns:
+    if columns:
+        if not cat.has_quantities(columns):
+            raise ValueError("Not all columns available in {}".format(reader))
+    else:
         columns = cat.list_all_quantities(include_native=include_native)
-        if is_tract_catalog and not include_native:
+        if isinstance(cat, DC2DMTractCatalog) and not include_native:
             for col in ("tract", "patch"):
                 if col not in columns and cat.has_quantity(col):
                     columns.append(col)
@@ -87,80 +119,107 @@ def convert_cat_to_parquet(reader,
     columns = new_columns
     del columns_sanitized, new_columns
 
-    def chunk_data_generator():
-        for data in cat.get_quantities(columns, return_iterator=True):
-            table = pa_table_from_pydict(data)
-            del data
-            try:
-                cat.close_all_file_handles()
-            except (AttributeError, TypeError):
-                pass
-            yield table
+    my_print("Determining partition scheme")
+    partition_values = None
+    if partition:
+        if isinstance(cat, DC2DMTractCatalog):
+            partition = "tract"
+            partition_values = sorted(cat.available_tracts)
+            filename_postfix = "_tract{}"
+        elif "healpix_pixel" in cat.native_filter_quantities and hasattr(cat, "_file_list"):
+            partition = "healpix_pixel"
+            partition_values = sorted((k[1] for k in cat._file_list))
+            filename_postfix = "_healpix{}"
+        else:
+            partition = "iter"
+            filename_postfix = "_chunk{}"
+    else:
+        filename_postfix = ""
 
+    my_print("Partition scheme is", partition)
+    if partition_values:
+        my_print("Partition values are", partition_values)
+
+    # Format output filename
     if output_filename is None:
-        output_filename = str(reader) + '{}.parquet'
+        output_filename = str(reader) + filename_postfix + '.parquet'
     elif '{}' not in output_filename:
         if output_filename.endswith('.parquet'):
-            output_filename = output_filename[:-8] + '{}.parquet'
+            output_filename = output_filename[:-8] + filename_postfix + '.parquet'
         else:
-            output_filename = output_filename + '{}'
+            output_filename = output_filename + filename_postfix
 
-    chunk_iter = chunk_data_generator()
+    if not partition:
+        _write_one_partition(dict(cat=cat, columns=columns, output_path=output_filename))
 
-    if partition:
-        for i, table in enumerate(chunk_iter):
-            if is_tract_catalog:
-                output_filename_this = output_filename.format('_tract{}'.format(table.column('tract')[0]))
-            else:
-                output_filename_this = output_filename.format('_chunk{}'.format(i))
-            with pq.ParquetWriter(output_filename_this, table.schema, flavor='spark') as pqwriter:
+    elif partition == "iter":
+        for i, table in enumerate(_chunk_data_generator(cat, columns)):
+            output_path = output_filename.format(i)
+            my_print("Generating", output_path)
+            with pq.ParquetWriter(output_filename.format(i), table.schema, flavor='spark') as pqwriter:
                 pqwriter.write_table(table)
+            my_print("Done with", output_path)
+
+    elif partition_values:
+        kwargs_array = []
+        for value in partition_values:
+            kwargs_this = dict(
+                cat=cat,
+                columns=columns,
+                native_filters="{} == {}".format(partition, value),
+                output_path=output_filename.format(value),
+                silent=silent,
+            )
+            kwargs_array.append(kwargs_this)
+
+        n_cores = max(n_cores, 1)
+        with mp.Pool(n_cores) as pool:
+            pool.map(_write_one_partition, kwargs_array)
 
     else:
-        if is_tract_catalog and kwargs.get('tract'):
-            output_filename_this = output_filename.format('_tract{}'.format(kwargs['tract']))
-        elif kwargs.get('healpix_pixels'):
-            output_filename_this = output_filename.format('_healpix{}'.format(kwargs['healpix_pixels'][0]))
-        else:
-            output_filename_this = output_filename.format('')
-
-        table = next(chunk_iter)
-        with pq.ParquetWriter(output_filename_this, table.schema, flavor='spark') as pqwriter:
-            pqwriter.write_table(table)
-            for table in chunk_iter:
-                pqwriter.write_table(table)
+        raise ValueError("Unknown partition scheme")
 
 
 def main():
     usage = """
 Produce parquet output file from a catalog within GCRCatalogs. Requires pyarrow.
 
-For example, to produce an output Parquet file from the 'dc2_object_run2.2i_dr3' GCR catalog:
+To produce a single Parquet file from the 'dc2_object_run2.2i_dr3' GCR catalog:
 
   python %(prog)s dc2_object_run2.2i_dr3
 
 By default the output name will be 'dc2_object_run2.2i_dr3.parquet'.
 You could specify a different one on the command line:
 
-  python %(prog)s dc2_object_run2.2i_dr3 --output_filename dc2_object_test.parquet
+  python %(prog)s dc2_object_run2.2i_dr3 --output dc2_object_test.parquet
 
 For catalogs that use a reader that is based on GCRCatalogs.DC2DMTractCatalog (e.g., newer object catalogs),
-one can specify a tract to process:
+one can specify a subset of tracts to process. Use --partition to put each tract in one file.
 
-    python %(prog)s dc2_object_run2.2i_dr3 --tract 3830
+    python %(prog)s dc2_object_run2.2i_dr3 --tracts 3830 3831 --partition
 
-This would only process one tract and produce the file 'dc2_object_run2.2i_dr3_tract3830.parquet'
+This would process only two tracts and produce two files:
+'dc2_object_run2.2i_dr3_tract3830.parquet' and 'dc2_object_run2.2i_dr3_tract3831.parquet'
+
+If you want to process all tracts, but create one output file per tract, use just --partition.
+You can optionally specify --n-cores to speed things up.
+Because this is an I/O intensive work, it is *not* recommended that you use too many cores at once.
+
+   python %(prog)s dc2_object_run2.2i_dr3 --partition --n-cores=4
+
+If you are working with cosmoDC2, replace "tract" with "healpix" and the above instructions still apply.
 
 """
     parser = ArgumentParser(description=usage,
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument('reader', help='Catalog (name as in GCRCatalogs) to read.')
-    parser.add_argument('--output_filename', help='Output filename. Default to <reader>.parquet')
+    parser.add_argument('--output-filename', help='Output filename. Default to <reader>.parquet')
     parser.add_argument('--include_native', action='store_true',
                         help='Include the native quantities along with the derived GCR quantities')
     parser.add_argument('--partition', action='store_true', help='Store each chunk as a separate file')
-    parser.add_argument('--tract', type=int, help='tract to process')
-    parser.add_argument('--healpix', type=int, nargs=1, dest='healpix_pixels', help='healpix to process (for cosmoDC2)')
+    parser.add_argument('--tracts', type=int, nargs="+", help='Limiting tracts to process (for tract catalogs)')
+    parser.add_argument('--healpix-pixels', type=int, nargs="+", help='Limiting healpix pixels to process (for cosmoDC2)')
+    parser.add_argument("--n-cores", type=int, default=1)
 
     convert_cat_to_parquet(**vars(parser.parse_args()))
 


### PR DESCRIPTION
This PR enables three scripts to process multiple files at once:
- `scripts/repartition_into_tracts.py`: 
   Multiple input files are processed in serial, significantly reducing the overhead of starting python and loading skymap. Note that for each file, multiple cores are already used in the calculation of tract and patch.
- `scripts/merge_truth_per_tract.py`:
   Multiple input files can be processed in serial or parallel, depending on `--n-cores`.
- `scripts/write_gcr_to_parquet.py`:
   Multiple input files are processed in serial, reducing the overhead of starting python and loading catalog metadata. Python multiprocess is not used here because some catalogs in GCRCatalogs are not pickleable.

I have already tested all three scripts. 