### PR TITLE
Implement matching limits for truth-match catalog

### DIFF
--- a/scripts/merge_truth_per_tract.py
+++ b/scripts/merge_truth_per_tract.py
@@ -9,10 +9,12 @@ import re
 import warnings
 import multiprocessing as mp
 from argparse import ArgumentParser, RawTextHelpFormatter
+from collections import defaultdict
 
 import numpy as np
-from astropy.coordinates import SkyCoord
 import pandas as pd
+import astropy.units as u
+from astropy.coordinates import SkyCoord, search_around_sky
 
 __all__ = ["merge_truth_per_tract", "match_object_with_merged_truth"]
 
@@ -82,24 +84,48 @@ def merge_truth_per_tract(input_dir, truth_types=("truth_", "star_", "sn_"), val
     return df
 
 
-def match_object_with_merged_truth(truth_cat, object_cat, validate=False, silent=False, **kwargs):
-    """Match object catalog with truth catalog
+def _flux_to_mag(flux):
+    with np.errstate(divide="ignore"):
+        mag = (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
+    # Change inf to nan, useful for applying np.nanargmin later on
+    return np.where(np.isfinite(mag), mag, np.nan)
 
+
+def match_object_with_merged_truth(
+    truth_cat,
+    object_cat,
+    validate=False,
+    silent=False,
+    sep_limit_arcsec=1.0,
+    dmag_limit=1.0,
+    mag_band="r",
+    **kwargs
+):
+    """Match object catalog with truth catalog
     Parameters
     ----------
     truth_cat : pd.DataFrame or str
         Truth catalog or its path (needs to be a parquet file)
     object_cat : pd.DataFrame or str
         Object catalog or its path (needs to be a parquet file)
-
     Optional Parameters
     ----------------
     validate : bool, optional (default: False)
         If true, check the matching is perform properly.
     silent : bool, optional (default: False)
         If true, turn off most printout.
+    sep_limit_arcsec : float, optional (default: 1.0)
+        Separation limit to be considered a good match
+    dmag_limit : float, optional (default: 1.0)
+        Magnitude difference to be considered a good match
+    mag_band : float, optional (default: 1)
+        Band to use for the magnitude difference calculation
     """
-    my_print = (lambda *x: None) if silent else print
+    my_print = (lambda x: None) if silent else print
+
+    mag_label_obj = "mag_{}_cModel".format(mag_band)
+    mag_label_truth = "mag_{}".format(mag_band)
+    flux_label_truth = "flux_{}".format(mag_band)
 
     if isinstance(truth_cat, str):
         my_print("Loading truth catalog from", truth_cat)
@@ -107,35 +133,96 @@ def match_object_with_merged_truth(truth_cat, object_cat, validate=False, silent
 
     if isinstance(object_cat, str):
         my_print("Loading object catalog from", object_cat)
-        object_cat = pd.read_parquet(object_cat, columns=["objectId", "ra", "dec"])
+        object_cat = pd.read_parquet(object_cat, columns=["objectId", "ra", "dec", mag_label_obj])
 
     if "tract" in object_cat.columns and truth_cat.loc[0, "tract"] != object_cat.loc[0, "tract"]:
         warnings.warn("Tract number does not match between truth and object catalog!!")
 
-    my_print("Performing nearest neighbor match")
+    my_print("Performing catalog match...")
+
+    # Obtain SkyCoords
     object_sc = SkyCoord(object_cat["ra"].values, object_cat["dec"].values, unit="deg")
     truth_sc = SkyCoord(truth_cat["ra"].values, truth_cat["dec"].values, unit="deg")
-    idx, sep, _ = object_sc.match_to_catalog_sky(truth_sc)
-    del object_sc, truth_sc
 
-    my_print("Merging matching info with truth catalog")
-    matched = pd.DataFrame.from_dict({
-        "truth_idx": truth_cat.index.values[idx],
-        "match_sep": sep.arcsec,
-        "match_objectId": object_cat["objectId"]
-    })
-    del idx, sep
+    # Add magnitude to truth catalog for calculate magnitude difference
+    truth_cat[mag_label_truth] = _flux_to_mag(truth_cat[flux_label_truth].values)
 
+    # Find all pairs between object and truth that are separated within `sep_limit_arcsec`
+    obj_row_indices, truth_row_indices, sep, _ = search_around_sky(
+        object_sc,
+        truth_sc,
+        sep_limit_arcsec * u.arcsec,  # pylint: disable=no-member
+    )
+
+    matched = defaultdict(list)
+    # Group by `obj_row_indices`, and then iterate over each unique object row index (`obj_row_idx`)
+    # In the for loop below, recall that `(obj_row_indices[idx] == obj_row_idx).all() == True`
+    for obj_row_idx, idx in pd.RangeIndex(stop=obj_row_indices.size).groupby(obj_row_indices):
+        is_nearest = True
+        if len(idx) == 1:  # if only 1 truth match candidate for this object, choose that one
+            match_idx = idx.pop()
+        else:  # if more than 1 truth match candidates
+            nearest_idx = idx[np.argmin(sep[idx].arcsec)]  # keep track of the nearest one
+            mag_obj = object_cat.loc[obj_row_idx, mag_label_obj]
+            mag_truth = truth_cat.loc[truth_row_indices[idx], mag_label_truth]
+            # if valid magnitudes are available, switch to the one with smallest mag difference
+            if np.isfinite(mag_obj) and np.isfinite(mag_truth).any():
+                match_idx = idx[np.nanargmin(np.abs(mag_truth - mag_obj))]
+                is_nearest = (match_idx == nearest_idx)
+            else:  # otherwise, use the nearest one
+                match_idx = nearest_idx
+
+        matched["object_idx"].append(obj_row_idx)
+        matched["truth_idx"].append(truth_row_indices[match_idx])
+        matched["match_sep"].append(sep[match_idx].arcsec)
+        matched["is_nearest_neighbor"].append(is_nearest)
+
+    matched = pd.DataFrame.from_dict(matched)
+    del obj_row_indices, truth_row_indices, sep
+
+    # For any object entries that do not have a match yet, find the nearest neighbor
+    obj_not_matched_row_indices = np.in1d(object_cat.index.values, matched["obj_row_idx"].values, True, True)
+    truth_row_indices, sep, _ = object_sc[obj_not_matched_row_indices].match_to_catalog_sky(truth_sc)
+
+    matched = matched.append(
+        pd.DataFrame.from_dict({
+            "object_idx": obj_not_matched_row_indices,
+            "truth_idx": truth_row_indices,
+            "match_sep": sep.arcsec,
+            "is_nearest_neighbor": True,
+        }),
+        ignore_index=True,
+    )
+    del obj_not_matched_row_indices, truth_row_indices, sep, object_sc, truth_sc
+
+    # Check if any truth entry appears more than once, and mark those
     matched.sort_values("match_sep", inplace=True)
     matched["is_unique_truth_entry"] = ~matched.duplicated("truth_idx", keep="first")
-    matched.sort_index(inplace=True)
+    matched.sort_values("object_idx", inplace=True)
+    if validate:
+        (matched["object_idx"] == object_cat.index.values).all()
+    del match_idx["object_idx"]
 
+    # Recall that `matched` and `object_cat` are now in exactly the same order
+    matched["match_objectId"] = object_cat["objectId"].values
+    dmag = object_cat[mag_label_obj].values - truth_cat.loc[matched["truth_idx"], mag_label_truth].values
+    matched["is_good_match"] = (
+        (matched["match_sep"].values < sep_limit_arcsec) & np.isfinite(dmag) & (np.abs(dmag) < dmag_limit)
+    )
+    del dmag, truth_cat[mag_label_truth]
+
+    # Reorder the columns to be organized
+    matched = matched[["truth_idx", "match_objectId", "match_sep", "is_good_match", "is_nearest_neighbor", "is_unique_truth_entry"]]
+
+    # Prepare the remaining entries in the truth catalog that do not have matches
     not_matched_truth_idx = truth_cat.index.values[np.in1d(truth_cat.index.values, matched["truth_idx"].values, invert=True)]
     not_matched = pd.DataFrame.from_dict({
         "truth_idx": not_matched_truth_idx,
-        "match_sep": -1.0,
         "match_objectId": -1,
-        "is_unique_truth_entry": True
+        "match_sep": -1.0,
+        "is_good_match": False,
+        "is_nearest_neighbor": False,
+        "is_unique_truth_entry": True,
     })
 
     full_table = pd.concat([matched, not_matched], ignore_index=True)


### PR DESCRIPTION
This PR implements the truth matching limits (dmag < 1 and sep < 1") as described in the DC2 paper. For objects that do that have match with these limits, nearest neighbor is used as a match. A `is_good_match` column indicates whether the matching limits are met. 

With this implementation, the majority of matching entries are identical with Javi's catalog, but there's 0.1% of matches that differ. Upon inspection, this difference is due to the different sources of magnitude --- I used the magnitude in the truth catalog, while Javi used cosmoDC2. Because the algorithm choose the closest magnitude within 1" when multiple candidates exist, the small difference in magnitude results in different matches in the faint end.

![image](https://user-images.githubusercontent.com/3792659/101953999-57a79d80-3bc9-11eb-8178-15987f966fb4.png)

Note that this PR is current made w.r.t to the `u/yymao/allow-multiple-files` branch to highlight the relevant change. But it should be merged in to master in the end. 